### PR TITLE
North star architecture + honest 2026 accuracy scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # ⚾ Baseball Projections
 
-A Bayesian baseball projection system using PyMC — hierarchical models for hitter and pitcher projections. Built to produce competitive full-season projections grounded in modern Statcast data and classical reliability-weighted baselines.
+A baseball projection and simulation system — hierarchical Bayesian player models, a season Monte Carlo with MLB tiebreakers, and a backtest harness that scores everything against dumb baselines, public systems, and (next) the betting market. Also the template for a general ML factory: data → object store, honest eval harness, serverless training, scheduled agent sessions, public scoreboard.
 
-## Architecture — 6 Phases
+## Where things stand
 
-| Phase | Description | Status |
-|-------|-------------|--------|
-| **1. Data Pipelines + Marcel Baseline** | Historical stats (FanGraphs), Statcast data (Baseball Savant), park factors, and Marcel projection engine | ✅ Complete |
-| **2. Bayesian Hierarchical Models** | PyMC models for hitter and pitcher true-talent estimation | 🔨 In Progress |
-| **3. Projection Synthesis** | Blend Marcel baseline with Bayesian posteriors, aging curves, platoon splits | Planned |
-| **4. Team-Level Aggregation** | Depth charts, lineup optimization, team wins projections | Planned |
-| **5. In-Season Updates** | Live Bayesian updating as the season progresses | Planned |
-| **6. Evaluation & Dashboard** | Accuracy tracking, comparison to other systems, web dashboard | Planned |
+**North star:** beat the betting market's closing line, out of sample, and
+prove it on a public scoreboard. Read **[docs/architecture.md](docs/architecture.md)**
+first — it is the one document every session works against: the model
+rollup as stations, each station's baseline and current score, the gate rule
+for what gets wired into production, and the edge thesis.
 
-## Current Status
+| Doc | What it is |
+|---|---|
+| [docs/architecture.md](docs/architecture.md) | North star: stations, gate rule, edge thesis, sequencing |
+| [docs/roadmap.md](docs/roadmap.md) | Dated v1 plan (ship playoff odds by Sept 28, 2026) |
+| [docs/automation.md](docs/automation.md) | How work runs in the background (Modal cron + scheduled Claude sessions) |
+| [docs/accuracy-2026.md](docs/accuracy-2026.md) | Honest scoreboard: our models vs Steamer/ZiPS/Depth Charts, per-game Brier |
+| [docs/backtest-baselines.md](docs/backtest-baselines.md) | Marcel / naive baselines 2019–2025 that every component must beat |
+| [docs/playoff-odds-validation.md](docs/playoff-odds-validation.md) | Simulator vs FanGraphs |
 
-**Phase 1 is complete.** The project includes:
-
-- **Historical data pipeline** — Fetches seasonal hitter/pitcher stats from FanGraphs (2000–present)
-- **Statcast pipeline** — Downloads pitch-level data from Baseball Savant (2015–present)
-- **Park factors** — Computes multi-year regressed park factors by team
-- **Marcel projections** — Tom Tango's Marcel the Monkey system: reliability-weighted 3-year averages with age adjustment and regression to league mean
+**Live today:** playoff odds for all 30 teams (`public/`), regenerated nightly
+with dated snapshots. **Not yet earned:** the Bayesian player components,
+which currently tie Marcel and trail Depth Charts, stay out of the rollup
+until they beat their baseline in the harness.
 
 ## Setup
 

--- a/docs/accuracy-2026.md
+++ b/docs/accuracy-2026.md
@@ -63,6 +63,22 @@ the per-game edge frontier, not team strength.
 
 Calibration is good in the .40–.65 band; the extreme buckets are tiny.
 
+## 2b. Why "close to FanGraphs on playoff odds" means nothing in September
+
+Mean absolute gap to FanGraphs playoff odds, Sept 1, 8,000 sims each:
+
+| Strength model | P(playoffs) | P(division) | P(WS) | Exp. wins |
+|---|---|---|---|---|
+| **No model — every team is a .500 coin flip** | 1.94 | 1.78 | 1.30 | 1.06 |
+| Ours (regressed Pythagenpat) | 1.63 | 2.10 | 1.37 | 0.66 |
+
+A simulator with **no team-strength model whatsoever** lands within 2 points of
+FanGraphs. With 26 games left, playoff odds are ~90% standings arithmetic; the
+strength model only moves the margin (mostly in expected wins). So the
+1.5-point agreement is a check that the *plumbing* is right — schedule,
+tiebreakers, bracket — not evidence of modeling skill. Playoff odds become a
+model test in April, not September.
+
 ## 3. So where is edge?
 
 Not in September playoff odds (85% of the season is banked; being within

--- a/docs/accuracy-2026.md
+++ b/docs/accuracy-2026.md
@@ -1,0 +1,83 @@
+# 2026 Accuracy Scoreboard — where we actually stand
+
+**As of Sept 1, 2026** (season 85% complete). Reproduce with
+`python scripts/score_2026_projections.py` and
+`python scripts/backtest_game_odds.py --season 2026`.
+
+This page exists to answer one question honestly: **do our models have edge?**
+Right now the answer is no, and the numbers below say exactly where.
+
+## 1. Preseason player projections vs. 2026 actuals
+
+All systems scored on the **same 263 hitters** (≥150 PA), trials-weighted.
+Public systems as captured Apr 9; ours generated Apr 10. Lower is better.
+
+| Component | Depth Charts | ZiPS | Steamer | Marcel | **Bayes (ours)** | League avg |
+|---|---|---|---|---|---|---|
+| K% MAE | **.0234** | .0240 | .0256 | .0261 | .0271 | .0487 |
+| BB% MAE | **.0156** | .0163 | .0162 | .0173 | .0170 | .0250 |
+| HR/PA MAE | **.0081** | .0085 | .0087 | .0088 | .0091 | .0115 |
+| ISO MAE | **.0289** | .0316 | .0317 | .0321 | .0333 | .0403 |
+| BABIP MAE | **.0211** | .0214 | .0221 | .0235 | .0239 | .0252 |
+
+**Reading it:**
+
+- **Our five Bayesian components rank last among the real systems on every
+  component and roughly tie Marcel.** They are not broken — they beat league
+  average by the same margin everyone does — but a hierarchical model with
+  HSGP aging curves is currently delivering Marcel-level accuracy. That is the
+  finding, and it is exactly what the roadmap's "expect the numbers to be worse
+  than you thought" warned.
+- **Depth Charts wins everything.** It is a *consensus* (Steamer + ZiPS blend)
+  with hand-curated playing time. Consensus beating any single model is the
+  normal state of the world; it is also the bar.
+- **The spread between systems is small.** Depth Charts to Marcel on K% is
+  .0027 MAE on a stat with a .048 league-average error. Most of what's
+  predictable is captured by "weight the last three years and regress."
+
+The likely reasons ours trails, in the order to test with the harness:
+1. **Fake ages** — every projection here was made with `birth_year = debut - 24`
+   (fixed in 0.1, not yet refit). The aging term was learning noise.
+2. **No pitcher effect** — a batter's K% is partly who he faced (0.5).
+3. **Over-regression** — the hyperpriors may shrink stars toward the mean
+   harder than the data warrants; check by scoring the top/bottom deciles.
+
+## 2. Day-to-day: per-game win probability, walk-forward
+
+1,757 games of 2026 predicted one day at a time using only prior results.
+
+| Model | Brier | Log loss |
+|---|---|---|
+| Pythagenpat, 100-game ballast | **.2476** | **.6884** |
+| Pythagenpat, 60 (production) | .2478 | .6887 |
+| Pythagenpat, 30 | .2484 | .6901 |
+| Home team always (53.5%) | .2497 | .6926 |
+| Raw win% into log5 | .2529 | .7002 |
+
+**Reading it:** the production strength model beats "always pick the home
+team" by 0.002 Brier. That is real but tiny — single MLB games are close to
+coin flips, and a team-level strength number is a blunt instrument. Betting
+markets score around .240–.245 here because they price the things we ignore:
+**starting pitcher, lineup, bullpen availability, park, weather.** That is
+the per-game edge frontier, not team strength.
+
+Calibration is good in the .40–.65 band; the extreme buckets are tiny.
+
+## 3. So where is edge?
+
+Not in September playoff odds (85% of the season is banked; being within
+1.5 pts of FanGraphs is arithmetic, not modeling), and not in team-level
+per-game odds. The plausible pockets, each testable in the harness:
+
+| Pocket | Why public systems may be weak there | How we'd know |
+|---|---|---|
+| **Per-game with starters/lineups/bullpen** | Public projection systems don't publish game odds; the market does, and it's beatable at the margins with better pitcher-quality models (Stuff+, roadmap cut list for v1). | Brier vs. market closing line, walk-forward. |
+| **Uncertainty, not point estimates** | Public systems publish a number; contract and trade valuation need a *distribution*. A calibrated 10th/90th percentile is a product no one is selling. | Coverage tests (roadmap 5.7). |
+| **Long horizons (3–5 yrs)** | Steamer/ZiPS are one-year systems; ZiPS' long-term is a heuristic. Dynamic skill + aging + health (Phase 5) is a real structural difference. | Backtest 2010→2015 careers. |
+| **Statcast-informed components** | Marcel and friends use outcomes; batted-ball and swing data carry signal about *future* outcomes (xwOBA-style). Our PA-level models are positioned to use it and currently don't. | Same harness, add features, watch MAE. |
+| **Rookies / low-sample players** | Where regression-to-mean systems are weakest; hierarchical pooling across minor-league and Statcast data should shine. | Score the <200-PA-history cohort separately. |
+
+The honest position: the infrastructure is the asset. Most model ideas will
+not beat Depth Charts, and the harness will say so in minutes rather than
+letting us believe otherwise for a season. The ones that survive are the
+edge.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,172 @@
+# North Star Architecture
+
+**The one document every session works against.** The roadmap
+([roadmap.md](roadmap.md)) is the dated plan; the factory design
+([automation.md](automation.md)) is how work gets done in the background;
+this is the *system* — what feeds what, where each piece stands, and the rule
+that decides when a piece is allowed into production.
+
+Last updated: Sept 1, 2026.
+
+## 0. The north star
+
+**Beat the market.** Not FanGraphs, not Marcel — the betting market's
+closing line, which is the best publicly available probability for a baseball
+event and prices in everything the public systems know plus sharp money. If
+our probabilities beat the de-vigged closing line out of sample, that is edge
+that pays; if they don't, no amount of Bayesian elegance matters.
+
+Everything else in this document is instrumentation toward that. The longer
+arc is the same skeleton pointed at financial markets: **the market is the
+baseline, walk-forward is the only valid test, calibration and sizing are
+where the money is made or lost**, and the factory exists to run that loop
+without fooling ourselves. Sports markets are the training ground because
+they are less efficient than financial ones and settle every night.
+
+The scoreboard that matters (station **M** below):
+
+| Market | Our model | Metric | Money metric |
+|---|---|---|---|
+| Moneyline (game winner) | Station E | Log loss / Brier vs de-vigged closing line | Simulated ROI + closing-line value (CLV) on bets where \|ours − market\| > threshold |
+| Totals (runs) | Station C + E | Same | Same |
+| **Player props** (K, HR, hits, TB) | **Station A directly** | Log loss vs prop line | Same |
+| Futures (division, pennant, WS) | Station G | Log loss at season checkpoints | Same, long-dated |
+
+**Player props are the shortest path to money.** A K% model that beats the
+strikeout-prop market monetizes station A on its own, without the whole
+rollup working. It is also the cleanest possible test of whether the
+Bayesian components have edge, because the prop line already embeds Steamer,
+ZiPS, and the sharps.
+
+Ground rules that carry over to finance unchanged:
+1. **The market is the baseline** for every station that has one. Beating
+   Marcel is a unit test; beating the closing line is the exam.
+2. **Archive market lines daily starting now.** Closing lines cannot be
+   reconstructed later; without the archive there is no backtest. Same
+   principle as the odds snapshots (roadmap 3.1).
+3. **Score in money terms, not just probability terms.** A model can have
+   better log loss and lose money (edge concentrated where vig is highest)
+   or worse log loss and make money (edge concentrated on mispriced tails).
+   Report both; CLV is the leading indicator, ROI the lagging one.
+4. **Walk-forward only; no peeking.** Every prediction uses only data
+   available before the line closed. The harness's leakage guard is the
+   most important line of code in the repo.
+5. **Sizing is part of the model.** Fractional Kelly on the calibrated
+   edge; a miscalibrated model with correct point estimates still loses.
+   Calibration (edge pocket #3) is therefore not a nicety.
+6. **Deep learning earns its place the same way** — where the data is
+   high-dimensional and sequential (pitch-level tracking, swing paths,
+   order flow later), scored against the same baselines in the same harness.
+
+## 1. The rollup
+
+Everything on the site is a rollup of models below it. Each arrow is a
+**station**: an input contract, a swap point in code, a baseline, and a score.
+
+```
+ Statcast PA data ─┐
+ Chadwick ages ────┼─► [A] Player rate models ──► [C] Team run environment ──► [D] Team strength
+ Pitchers faced ───┘        K% BB% HR ISO BABIP        RS/G, RA/G per team          talent win%
+                                   ▲                          ▲                          │
+ Rosters, IL, PA share ──► [B] Playing time ──────────────────┘                          ▼
+                                                                                 [E] Per-game P(win)
+ Starters, lineups, bullpen, park, weather ──────────────────────────────────────────────┤
+                                                                                         ▼
+ Schedule + results (Stats API) ───────────────────────────────────────► [F] Season Monte Carlo
+                                                                          tiebreakers, bracket
+                                                                                         ▼
+                                                              [G] Standings, playoff odds, pennant, WS
+                                                                                         ▼
+                                                                          [H] Site + daily snapshot archive
+```
+
+**Today the chain is wired from [D] down and bypassed above it.** Team
+strength comes straight from the standings' run differential, so the live
+playoff odds contain no player modeling. That is deliberate for v1 (it ships)
+and it must stay that way until [A]–[C] beat their baselines.
+
+## 2. Station status
+
+| Station | What it is | Baseline to beat | Current best (Sept 1) | Status | Swap point |
+|---|---|---|---|---|---|
+| **A. Player rates** | K%, BB%, HR/PA, ISO, BABIP projections | Marcel (K% MAE .0261 on 2026) | Depth Charts .0234 · **ours .0271 (last)** | Built, **loses to Marcel** → not wired | `src/eval` providers; `data/projections/*.parquet` |
+| **B. Playing time** | PA per player, rest of season | Recent-30-day PA share | — | Not built (roadmap 1.3) | `src/sim/strength.from_run_environment` inputs |
+| **C. Team run env.** | Projected RS/G, RA/G per team from A×B | Season-to-date runs, regressed | — | Not built (roadmap 1.5) | `strength.from_run_environment(rs, ra)` |
+| **D. Team strength** | Talent win% | Every team .500 (coin flip) | Regressed Pythagenpat, 60-game ballast | **Wired, live** | `src/sim/strength.py` |
+| **E. Per-game P(win)** | Home win prob for one game | Home team always (Brier .2497) | log5 + HFA: **.2478** · market ≈ .240–.245 | Wired; no starter/lineup terms | `strength.home_win_prob` |
+| **F. Season sim** | Monte Carlo, MLB tiebreakers, bracket | — (plumbing) | Within 1.6 pts of FanGraphs; coin-flip control within 1.9 | **Wired, validated** | `src/sim/season.py`, `standings.py`, `bracket.py` |
+| **G. Odds** | P(playoffs/div/bye/pennant/WS), win bands | — | Live, 20k sims | **Wired, live** | `src/sim/odds.py` |
+| **H. Site + archive** | Landing page, dated JSON, nightly job | — | Live; first snapshot 2026-09-01 | **Wired**; nightly first run pending | `scripts/run_playoff_odds.py`, `nightly-odds.yml` |
+| **M. Market** | Daily archive of moneyline / totals / props closing lines; de-vig; score E/A/G against them; simulated ROI + CLV | The closing line itself | — | **Not built** — highest-priority new station | `src/market/` (to create); The Odds API (key needed), SportsbookReview history |
+
+Scoreboards: [accuracy-2026.md](accuracy-2026.md) (stations A, E, G),
+[backtest-baselines.md](backtest-baselines.md) (station A baselines
+2019–2025), [playoff-odds-validation.md](playoff-odds-validation.md) (G).
+
+## 3. The gate rule
+
+> A station's model is wired into production only when it beats the
+> station's baseline out of sample in the harness, on the common player or
+> game set, and is recorded on the scoreboard. Until then the baseline runs.
+
+Consequences:
+- **Bayesian components stay out of the rollup** until they beat Marcel.
+  Wiring them in today would make the odds *worse*, not better.
+- **Baselines are production code**, not scaffolding. Marcel, regressed
+  Pythagenpat, and "home team always" ship until dethroned.
+- **A PR that changes a model must include harness output.** No numbers, no
+  merge. The factory worker enforces this.
+- **Agreement with FanGraphs is not a score.** The coin-flip control proved
+  September playoff odds can't distinguish models; use per-game Brier and
+  component MAE.
+
+## 4. Edge thesis — where we expect to win, and how we'd know
+
+Ordered by (expected payoff × how soon we can test it).
+
+| # | Pocket | Why public systems are beatable there | Test | Station |
+|---|---|---|---|---|
+| 1 | **Fix what's broken in A** | Our fits used fake ages and no pitcher effect. Refit with real ages (done in code) + pitcher random effect and re-score. If we don't reach Depth Charts we learn the structure isn't the problem. | Component MAE vs Marcel/DC on 2020–2026 | A |
+| 2 | **Per-game with starters, lineups, bullpen** | Public projection systems don't publish game odds; the market does. Team strength gets Brier .2478; market ≈ .243. The 0.005 between is pitcher-quality and lineup information. | Walk-forward Brier vs. market closing lines | E |
+| 3 | **Calibrated uncertainty** | Everyone publishes a point estimate. Contract valuation (Phase 6) needs a distribution; a 10th/90th band that actually covers 80% is a product no one sells. | Coverage tests (roadmap 5.7) | A, G |
+| 4 | **Statcast-informed rates** | Marcel/Steamer/ZiPS use outcomes; batted-ball and swing data lead outcomes. Our PA-level models are positioned to use them and don't yet. | Same harness, add features | A |
+| 5 | **Rookies and low-sample players** | Regression-to-mean systems are weakest exactly where hierarchical pooling (with minor-league / Statcast priors) is strongest. | Score the <200-PA-history cohort separately | A |
+| 6 | **Multi-year horizons** | Steamer/ZiPS are one-year systems; long-term public projections are heuristics. Dynamic skill + component aging + health (Phase 5) is a structural difference. | Backtest 2010→2015 careers | A→Phase 5 |
+
+What is **not** edge: September playoff odds, team-level per-game odds, and
+any component where the harness says skill ≈ noise (BABIP: league average
+ties Marcel).
+
+## 5. Sequencing from here
+
+Keyless work (runs in any cloud session now):
+0. **Station M, archive first** — nightly job pulls today's moneyline,
+   totals, and available props and writes a dated snapshot. One free Odds
+   API key (`ODDS_API_KEY`, 500 req/month) covers a daily pull. Backfill
+   2026 closing lines from SportsbookReview history so E can be scored
+   against the market immediately, not next year.
+1. **Wire the rollup with baselines** — B (playing time from Stats API
+   rosters), C (Marcel rest-of-season rates × PA → RS/RA), then flip D to
+   `from_run_environment`. Score against the coin-flip and current D on
+   per-game Brier. This makes the chain real end-to-end with honest parts,
+   so any later A improvement flows to the site automatically.
+2. **Station E v1** — probable starters from the Stats API + a pitcher
+   Marcel; score on Brier **and against the market** (M). This is edge
+   pocket #2 and the postseason odds driver.
+2b. **Props pipeline** — map station A's K%/HR projections + station B's
+   PA to per-game prop probabilities; score against archived prop lines.
+   First direct test of whether A has monetizable edge.
+3. **Accuracy page** on the site from the scoreboard docs (roadmap 3, page 4).
+
+Needs R2 / Modal / W&B:
+4. **Edge pocket #1** — refit A with real ages + binomial likelihood +
+   pitcher effect; re-score 2020–2026 vs Marcel and Depth Charts.
+5. Decide, from the number, whether A earns a place in C.
+
+## 6. Definition of "working against it"
+
+Every task in the queue names its station and its baseline. A task is done
+when the scoreboard row for that station changes (or the doc records that it
+didn't and why). Anything that can't be expressed that way is infrastructure,
+and infrastructure is judged by whether it makes the next scoreboard change
+cheaper.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,53 +10,66 @@ Last updated: Sept 1, 2026.
 
 ## 0. The north star
 
-**Beat the market.** Not FanGraphs, not Marcel — the betting market's
-closing line, which is the best publicly available probability for a baseball
-event and prices in everything the public systems know plus sharp money. If
-our probabilities beat the de-vigged closing line out of sample, that is edge
-that pays; if they don't, no amount of Bayesian elegance matters.
+**Truth first; the market is the bar; money is the exam.**
 
-Everything else in this document is instrumentation toward that. The longer
-arc is the same skeleton pointed at financial markets: **the market is the
-baseline, walk-forward is the only valid test, calibration and sizing are
-where the money is made or lost**, and the factory exists to run that loop
-without fooling ourselves. Sports markets are the training ground because
-they are less efficient than financial ones and settle every night.
+- **Primary objective: accuracy against reality**, measured with proper
+  scoring rules (log loss, Brier, calibrated intervals) on outcomes that
+  actually happened. Marcel, Depth Charts, and the market price are all
+  *baselines* for that one score. Beating Marcel is a unit test; beating the
+  market is the exam — but it is the same test, with a harder benchmark.
+- **The market is the strongest available baseline** wherever one exists.
+  For per-game outcomes, totals, props, and futures, our probability is
+  compared to the market's implied probability on the same event, out of
+  sample. Public projection systems already live inside that price.
+- **Money is a second scoreboard, not a second truth.** It adds three things
+  accuracy alone cannot see: a **hurdle** (fees/vig), **selectivity** (we
+  need to be right where we *disagree* with the market, not everywhere), and
+  **sizing** (fractional Kelly on a calibrated edge; a miscalibrated model
+  with good point estimates still loses). Money metrics — closing-line value
+  as the leading indicator, simulated ROI with confidence intervals as the
+  lagging one — decide *what to bet*. They never decide *what is true*.
+- **Why not optimize against the market directly:** Goodhart. A model fit
+  to the market's mistakes learns things like "fade day-game favorites" that
+  vanish when the market adapts. Player rates don't adapt. Truth-based
+  scoring keeps the model about baseball; the gate rule (§3) stays
+  truth-based for that reason.
 
-The scoreboard that matters (station **M** below):
+**Two model classes, one harness.**
 
-| Market | Our model | Metric | Money metric |
+| Class | Inputs | Scored on | Used for |
 |---|---|---|---|
-| Moneyline (game winner) | Station E | Log loss / Brier vs de-vigged closing line | Simulated ROI + closing-line value (CLV) on bets where \|ours − market\| > threshold |
-| Totals (runs) | Station C + E | Same | Same |
-| **Player props** (K, HR, hits, TB) | **Station A directly** | Log loss vs prop line | Same |
-| Futures (division, pennant, WS) | Station G | Log loss at season checkpoints | Same, long-dated |
+| **Independent** | Our data only — no market prices as features | Truth | The site, the accuracy page, career and contract valuation (no market exists for 5-year WAR) |
+| **Market-anchored** | Market price as a feature + our private information (pitcher quality, lineups, rates) | Truth *and* money | Betting. This is how professionals actually do it, and it cannot claim independent skill |
+
+**Venues (station M).** Two kinds, and they play different roles:
+
+| Venue | Examples | How they price | What caps you | Role for us |
+|---|---|---|---|---|
+| **Sportsbooks** | Pinnacle, DraftKings, FanDuel | Book sets the line, takes vig (2–4.5 pts moneyline, more on props) | **They limit or ban winning accounts** | The sharpest *reference price* (Pinnacle close). Archive it as the accuracy benchmark; do not plan to scale money there. |
+| **Prediction markets / exchanges** | Kalshi (CFTC-regulated, US), Polymarket | Order book; you trade against other participants, pay a small maker/taker fee | **Liquidity and position limits, not account bans** — you can only win what counterparties will lose | The **money venue**. No ban risk, you can be a *maker* (earn the spread instead of paying it), and the order-book mechanics are the same as finance: fills, slippage, adverse selection, inventory. |
+
+Prediction-market sports prices are typically less sharp than Pinnacle,
+especially props, futures, and mid-liquidity contracts, so edge is more
+plausible there — and book-vs-exchange price gaps are a low-model-risk
+first trade. Both venues expose **public market-data APIs with no key**
+(Kalshi trade-api v2: markets, order book, trades, settled history;
+Polymarket Gamma/CLOB/data APIs). Archive both daily; score against both.
 
 **Player props are the shortest path to money.** A K% model that beats the
-strikeout-prop market monetizes station A on its own, without the whole
-rollup working. It is also the cleanest possible test of whether the
-Bayesian components have edge, because the prop line already embeds Steamer,
-ZiPS, and the sharps.
+strikeout-prop price monetizes station A on its own, without the whole
+rollup working, and it is the cleanest test of whether the Bayesian
+components have edge, because the prop price already embeds Steamer, ZiPS,
+and the sharps.
 
-Ground rules that carry over to finance unchanged:
-1. **The market is the baseline** for every station that has one. Beating
-   Marcel is a unit test; beating the closing line is the exam.
-2. **Archive market lines daily starting now.** Closing lines cannot be
-   reconstructed later; without the archive there is no backtest. Same
-   principle as the odds snapshots (roadmap 3.1).
-3. **Score in money terms, not just probability terms.** A model can have
-   better log loss and lose money (edge concentrated where vig is highest)
-   or worse log loss and make money (edge concentrated on mispriced tails).
-   Report both; CLV is the leading indicator, ROI the lagging one.
-4. **Walk-forward only; no peeking.** Every prediction uses only data
-   available before the line closed. The harness's leakage guard is the
-   most important line of code in the repo.
-5. **Sizing is part of the model.** Fractional Kelly on the calibrated
-   edge; a miscalibrated model with correct point estimates still loses.
-   Calibration (edge pocket #3) is therefore not a nicety.
-6. **Deep learning earns its place the same way** — where the data is
-   high-dimensional and sequential (pitch-level tracking, swing paths,
-   order flow later), scored against the same baselines in the same harness.
+**Ground rules that carry to financial markets unchanged:** the market is
+the baseline; walk-forward only — every prediction uses only information
+available before the price you compare it to; archive prices daily starting
+now because they cannot be reconstructed; score in money terms *and*
+probability terms; sizing and execution (fills, not mids) are part of the
+model; deep learning earns its place in the same harness against the same
+baselines. Sports exchanges are the training ground because they are less
+efficient than financial ones, settle nightly, and have the same order-book
+structure.
 
 ## 1. The rollup
 
@@ -97,7 +110,7 @@ and it must stay that way until [A]–[C] beat their baselines.
 | **F. Season sim** | Monte Carlo, MLB tiebreakers, bracket | — (plumbing) | Within 1.6 pts of FanGraphs; coin-flip control within 1.9 | **Wired, validated** | `src/sim/season.py`, `standings.py`, `bracket.py` |
 | **G. Odds** | P(playoffs/div/bye/pennant/WS), win bands | — | Live, 20k sims | **Wired, live** | `src/sim/odds.py` |
 | **H. Site + archive** | Landing page, dated JSON, nightly job | — | Live; first snapshot 2026-09-01 | **Wired**; nightly first run pending | `scripts/run_playoff_odds.py`, `nightly-odds.yml` |
-| **M. Market** | Daily archive of moneyline / totals / props closing lines; de-vig; score E/A/G against them; simulated ROI + CLV | The closing line itself | — | **Not built** — highest-priority new station | `src/market/` (to create); The Odds API (key needed), SportsbookReview history |
+| **M. Market** | Daily archive of prices from **exchanges** (Kalshi, Polymarket: bid/ask, trades, settlement — public APIs, no key) and **sportsbooks** (closing lines via The Odds API / SportsbookReview); de-vig; score E/A/G against both; CLV + fill-aware simulated ROI | The market price itself | — | **Not built** — highest-priority new station | `src/market/` (to create) |
 
 Scoreboards: [accuracy-2026.md](accuracy-2026.md) (stations A, E, G),
 [backtest-baselines.md](backtest-baselines.md) (station A baselines
@@ -140,11 +153,12 @@ ties Marcel).
 ## 5. Sequencing from here
 
 Keyless work (runs in any cloud session now):
-0. **Station M, archive first** — nightly job pulls today's moneyline,
-   totals, and available props and writes a dated snapshot. One free Odds
-   API key (`ODDS_API_KEY`, 500 req/month) covers a daily pull. Backfill
-   2026 closing lines from SportsbookReview history so E can be scored
-   against the market immediately, not next year.
+0. **Station M, archive first** — nightly job snapshots Kalshi and
+   Polymarket MLB markets (bid/ask, last, volume, open interest; **no key
+   needed**) plus sportsbook lines (Odds API free key, SportsbookReview
+   history), writes dated snapshots. Backfill 2026 from Kalshi's settled
+   markets + trade history and SportsbookReview so E can be scored against
+   both venues immediately, not next year.
 1. **Wire the rollup with baselines** — B (playing time from Stats API
    rosters), C (Marcel rest-of-season rates × PA → RS/RA), then flip D to
    `from_run_environment`. Score against the coin-flip and current D on

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -52,8 +52,9 @@ Agentic sessions do what cron cannot: implement roadmap items, diagnose why last
 night's numbers look wrong, fix broken pipelines, and open PRs. The machinery, all of
 which exists in Claude Code on the web today:
 
-1. **Work queue = GitHub issues.** Each roadmap item becomes an issue labeled
-   `factory:ready`, ordered by phase. Issues are the durable state between sessions —
+1. **Work queue = GitHub issues.** Each station task from
+   [architecture.md](architecture.md) becomes an issue labeled `factory:ready`,
+   naming its station and the baseline it must beat. Issues are the durable state between sessions —
    cloud containers are ephemeral, so nothing lives only in a conversation.
 2. **Scheduled Routines** (Claude Code cloud triggers) fire on a schedule and spawn a
    *fresh* session in this environment with a standing prompt. Two routines:
@@ -92,10 +93,16 @@ for Layer 1), never in the repo:
 
 | Credential | Status | Needed for |
 |---|---|---|
-| R2 keys (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) | ✅ present | reading/writing data |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | ❌ add | reading/writing Statcast + snapshots. Use these names: the platform injects its own `AWS_*` pair (not usable, not yours) |
 | `R2_ENDPOINT_URL`, `R2_BUCKET_NAME` | ❌ add | boto3/DuckDB against R2 |
 | `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` | ❌ add | sessions launching training/sim runs |
 | `WANDB_API_KEY` | ❌ add | reading run status, logging |
+| `ODDS_API_KEY` | ❌ add | station M market-line archive (The Odds API, free tier) |
+
+Everything in stations D–H runs **without any of these** (MLB Stats API and
+Chadwick are public), which is why the simulator, site, and nightly job shipped
+on day one. The nightly sim runs on GitHub Actions, not Modal, for that reason;
+Modal is reserved for Bayesian refits.
 
 Network policy must allow: `modal.com`, `api.wandb.ai`, the R2 endpoint,
 `statsapi.mlb.com`, `baseballsavant.mlb.com`, `github.com`, PyPI.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,14 @@
 **Written:** Sept 1, 2026
 **Hard deadline for v1:** Sept 28, 2026 (Wild Card round opens Sept 29)
 
+> **Status (Sept 1, end of day):** Phases 0.1, 0.2, 0.4, 2 (all of it), and
+> 3.1/3.2 landed on day one; the site's playoff-odds page is live with the
+> first snapshot. 0.3 was run for real and the existing Bayesian components
+> **tie Marcel and trail Depth Charts** — see
+> [accuracy-2026.md](accuracy-2026.md). The system-level view, the gate
+> rule, and the market-beating north star now live in
+> [architecture.md](architecture.md); this file stays the dated v1 plan.
+
 ## Calendar anchors
 
 | Date | Event |

--- a/scripts/backtest_game_odds.py
+++ b/scripts/backtest_game_odds.py
@@ -1,0 +1,125 @@
+"""Day-to-day backtest of per-game win probabilities (walk-forward).
+
+For every completed game of the season, rebuild each team's strength from
+ONLY the games played before that date, predict P(home wins), and score
+against the actual result. This is the honest test of the simulator's
+per-game engine — the playoff-odds table mostly reflects banked standings,
+but per-game probabilities are where a strength model actually earns edge.
+
+Metrics: Brier score and log loss (lower is better). Baselines:
+    home_constant   — P(home) = HFA prior, ignores teams entirely
+    win_pct_log5    — raw season win% into log5 + HFA (no regression)
+    pythag_60       — the production model (regressed Pythagenpat, 60 games)
+    pythag_{k}      — ballast sweep to see what the data prefers
+
+Usage:
+    python scripts/backtest_game_odds.py --season 2026 --min-games 20
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+import pandas as pd
+
+from src.data.mlb_stats_api import fetch_schedule
+from src.sim.season import from_schedule
+from src.sim.strength import HFA_PRIOR, home_win_prob, pythagenpat
+from src.sim.teams import fetch_teams
+
+
+def team_totals(games: pd.DataFrame, team_ids) -> pd.DataFrame:
+    """Runs scored/allowed, wins/losses per team from a completed-games frame."""
+    home = games.groupby("home_id").agg(rs=("home_score", "sum"), ra=("away_score", "sum"),
+                                        w=("home_win", "sum"), g=("home_win", "size"))
+    away = games.groupby("away_id").agg(rs=("away_score", "sum"), ra=("home_score", "sum"),
+                                        w=("home_win", lambda x: (~x).sum()), g=("home_win", "size"))
+    tot = home.add(away, fill_value=0).reindex(team_ids).fillna(0)
+    return tot
+
+
+def strengths(tot: pd.DataFrame, regress_games: float) -> pd.Series:
+    lg_rs = tot["rs"].sum() / max(tot["g"].sum(), 1)
+    lg_ra = tot["ra"].sum() / max(tot["g"].sum(), 1)
+    out = {}
+    for t, r in tot.iterrows():
+        rs_pg = (r["rs"] + regress_games * lg_rs) / (r["g"] + regress_games)
+        ra_pg = (r["ra"] + regress_games * lg_ra) / (r["g"] + regress_games)
+        out[t] = pythagenpat(rs_pg, ra_pg, 1.0)
+    return pd.Series(out)
+
+
+def walk_forward(completed: pd.DataFrame, team_ids, min_games: int,
+                 ballasts: list[float]) -> pd.DataFrame:
+    """One row per scored game with each model's P(home)."""
+    completed = completed.sort_values("date").reset_index(drop=True)
+    rows = []
+    for date, day in completed.groupby("date", sort=True):
+        before = completed[completed["date"] < date]
+        tot = team_totals(before, team_ids) if len(before) else None
+        if tot is None or tot["g"].min() < min_games:
+            continue
+        hfa_obs = (HFA_PRIOR * 2000 + before["home_win"].sum()) / (2000 + len(before))
+        wp = (tot["w"] / tot["g"]).clip(0.2, 0.8)
+        s_by_k = {k: strengths(tot, k) for k in ballasts}
+        for g in day.itertuples(index=False):
+            row = {"date": date, "home_id": g.home_id, "away_id": g.away_id,
+                   "home_win": bool(g.home_win),
+                   "home_constant": hfa_obs,
+                   "win_pct_log5": float(home_win_prob(wp[g.home_id], wp[g.away_id], hfa_obs))}
+            for k, s in s_by_k.items():
+                row[f"pythag_{int(k)}"] = float(home_win_prob(s[g.home_id], s[g.away_id], hfa_obs))
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def score(df: pd.DataFrame, models: list[str]) -> pd.DataFrame:
+    y = df["home_win"].astype(float).to_numpy()
+    out = []
+    for m in models:
+        p = np.clip(df[m].to_numpy(), 1e-6, 1 - 1e-6)
+        out.append({"model": m,
+                    "brier": float(np.mean((p - y) ** 2)),
+                    "log_loss": float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p))),
+                    "mean_p_home": float(p.mean())})
+    return pd.DataFrame(out).sort_values("brier").reset_index(drop=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--season", type=int, default=2026)
+    parser.add_argument("--min-games", type=int, default=20,
+                        help="skip dates until every team has this many games")
+    parser.add_argument("--ballasts", default="0,30,60,100,160")
+    args = parser.parse_args()
+    ballasts = [float(b) for b in args.ballasts.split(",")]
+
+    teams = fetch_teams(args.season)
+    sched = fetch_schedule(f"{args.season}-03-01", f"{args.season}-10-15")
+    state = from_schedule(sched, teams)
+    # from_schedule drops scores; re-attach for run totals
+    scored = sched[sched["status"] == "Final"].dropna(subset=["home_score", "away_score"])
+    scored = scored[scored["home_score"] != scored["away_score"]].copy()
+    scored["home_win"] = scored["home_score"] > scored["away_score"]
+    scored = scored[scored["game_type"] == "R"]
+
+    preds = walk_forward(scored, teams["team_id"].to_numpy(), args.min_games, ballasts)
+    models = ["home_constant", "win_pct_log5"] + [f"pythag_{int(k)}" for k in ballasts]
+    print(f"{len(preds)} games scored (from the date every team had {args.min_games}+ games)\n")
+    print(score(preds, models).round(4).to_string(index=False))
+    # Calibration of the production model
+    prod = preds[["home_win", "pythag_60"]].copy()
+    prod["bucket"] = pd.cut(prod["pythag_60"], [0, .4, .45, .5, .55, .6, .65, 1.0])
+    cal = prod.groupby("bucket", observed=True).agg(n=("home_win", "size"),
+                                                   predicted=("pythag_60", "mean"),
+                                                   realized=("home_win", "mean"))
+    print("\nCalibration (pythag_60):")
+    print(cal.round(3).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_2026_projections.py
+++ b/scripts/score_2026_projections.py
@@ -1,0 +1,61 @@
+"""Score the preseason 2026 projections — ours and the public systems —
+against 2026 actuals, on the same players (roadmap 0.3 / accuracy page).
+
+Providers: our Bayesian preseason files (data/projections/*_2026.parquet,
+generated ~Apr 10), Steamer / ZiPS / Depth Charts as captured Apr 9
+(data/projections/comparison_2026.parquet), Marcel and league average
+fit on 2015-2025 season totals.
+
+Usage:
+    python scripts/score_2026_projections.py [--min-trials 150]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pandas as pd
+
+from src.eval import backtest, frame_provider, score
+from src.eval.baselines import BASELINES
+
+ROOT = Path(__file__).resolve().parent.parent
+COMPONENTS = ["k_rate", "bb_rate", "hr_rate", "iso", "babip"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-trials", type=int, default=150)
+    args = parser.parse_args()
+
+    seasons = pd.read_parquet(ROOT / "data/parquet/hitter_seasons_api.parquet")
+    public = pd.read_parquet(ROOT / "data/projections/comparison_2026.parquet")
+    tables = []
+    for c in COMPONENTS:
+        ours = pd.read_parquet(ROOT / f"data/projections/{c}_projections_2026.parquet")
+        providers = {
+            "bayes_preseason": frame_provider(ours, pred_col=f"projected_{c}"),
+            "steamer": frame_provider(public, pred_col=f"stea_{c}"),
+            "zips": frame_provider(public, pred_col=f"zips_{c}"),
+            "depth_charts": frame_provider(public, pred_col=f"dept_{c}"),
+            "marcel": BASELINES["marcel"],
+            "league_average": BASELINES["league_average"],
+        }
+        results = backtest(c, 2025, 2026, seasons=seasons, providers=providers,
+                           min_trials=args.min_trials)
+        tables.append(score(results))
+    out = pd.concat(tables).reset_index(drop=True)
+    print(out.round(5).to_string(index=False))
+
+    ranks = (out.groupby("component")
+             .apply(lambda g: g.set_index("model")["mae"].rank(), include_groups=False)
+             .unstack(0))
+    print("\nMAE rank by component (1 = best):")
+    print(ranks.assign(mean_rank=ranks.mean(1)).sort_values("mean_rank").round(1).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -3,6 +3,9 @@
 The factory's objective function: every model change is judged by
 `backtest()` numbers against dumb baselines, never by eyeball.
 """
-from src.eval.backtest import backtest, score, calibration, COMPONENTS
+from src.eval.backtest import (
+    backtest, score, calibration, COMPONENTS, parquet_provider, frame_provider,
+)
 
-__all__ = ["backtest", "score", "calibration", "COMPONENTS"]
+__all__ = ["backtest", "score", "calibration", "COMPONENTS",
+           "parquet_provider", "frame_provider"]

--- a/src/eval/backtest.py
+++ b/src/eval/backtest.py
@@ -55,6 +55,7 @@ def backtest(
     seasons: pd.DataFrame,
     providers: dict[str, Provider] | None = None,
     min_trials: int = 100,
+    common_players: bool = True,
 ) -> pd.DataFrame:
     """Run one train/predict split for one component.
 
@@ -67,6 +68,10 @@ def backtest(
             Add your model with e.g. {"bayes": parquet_provider(path), **BASELINES}.
         min_trials: drop realized seasons below this many trials — tiny
             samples measure noise, not skill.
+        common_players: score every model on the same batters (the
+            intersection of their coverage). Without this a model that
+            covers rookies is scored on a harder population than one that
+            doesn't, and the comparison is meaningless.
 
     Returns:
         Long frame: [component, model, batter, predicted, realized_successes,
@@ -94,9 +99,21 @@ def backtest(
         columns={spec.successes: "realized_successes", spec.trials: "trials"}
     )
 
-    frames = []
+    preds = {}
     for name, provider in providers.items():
         pred = provider(train, spec, predict_year)[["batter", "predicted"]]
+        pred = pred.dropna(subset=["predicted"])
+        if pred["batter"].duplicated().any():
+            raise ValueError(f"provider {name!r} returned duplicate batters")
+        preds[name] = pred
+    if common_players:
+        keep = set(realized["batter"])
+        for pred in preds.values():
+            keep &= set(pred["batter"])
+        realized = realized[realized["batter"].isin(keep)]
+
+    frames = []
+    for name, pred in preds.items():
         joined = realized.merge(pred, on="batter", how="inner")
         joined["model"] = name
         joined["component"] = component
@@ -153,8 +170,29 @@ def parquet_provider(
     path = Path(path)
 
     def provider(train: pd.DataFrame, spec: ComponentSpec, predict_year: int) -> pd.DataFrame:
-        df = pd.read_parquet(path)
-        return df.rename(
+        return frame_provider(pd.read_parquet(path), batter_col, pred_col)(
+            train, spec, predict_year)
+
+    return provider
+
+
+def frame_provider(
+    df: pd.DataFrame,
+    batter_col: str = "batter",
+    pred_col: str = "predicted",
+    year_col: str = "projection_year",
+) -> Provider:
+    """Wrap an in-memory projections frame as a provider.
+
+    If `year_col` is present (multi-year projection files), only rows for
+    the backtest's predict year are used.
+    """
+
+    def provider(train: pd.DataFrame, spec: ComponentSpec, predict_year: int) -> pd.DataFrame:
+        out = df
+        if year_col in out.columns:
+            out = out[out[year_col] == predict_year]
+        return out.rename(
             columns={batter_col: "batter", pred_col: "predicted"}
         )[["batter", "predicted"]]
 

--- a/tests/test_eval/test_backtest.py
+++ b/tests/test_eval/test_backtest.py
@@ -123,3 +123,32 @@ class TestBacktest:
             providers={"bayes": parquet_provider(path, pred_col="proj_k")},
         )
         assert score(results).iloc[0]["mae"] == pytest.approx(0.0, abs=1e-9)
+
+
+class TestProviderFairness:
+    def test_common_players_intersection(self, seasons):
+        # A provider that only knows batter 1 forces everyone onto batter 1.
+        narrow = lambda train, spec, y: pd.DataFrame({"batter": [1], "predicted": [0.15]})
+        results = backtest("k_rate", 2023, seasons=seasons,
+                           providers={"narrow": narrow, "prev": previous_season})
+        assert set(results["batter"]) == {1}
+        wide = backtest("k_rate", 2023, seasons=seasons,
+                        providers={"narrow": narrow, "prev": previous_season},
+                        common_players=False)
+        assert set(wide[wide.model == "prev"]["batter"]) == {1, 2, 3}
+
+    def test_multi_year_file_selects_predict_year(self, seasons):
+        from src.eval.backtest import frame_provider
+        df = pd.DataFrame({
+            "batter": [1, 1, 2, 2, 3, 3],
+            "projection_year": [2024, 2025] * 3,
+            "proj": [0.15, 0.99, 0.25, 0.99, 0.35, 0.99],
+        })
+        results = backtest("k_rate", 2023, 2024, seasons=seasons,
+                           providers={"f": frame_provider(df, pred_col="proj")})
+        assert score(results).iloc[0]["mae"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_duplicate_batters_rejected(self, seasons):
+        dup = lambda train, spec, y: pd.DataFrame({"batter": [1, 1], "predicted": [0.1, 0.2]})
+        with pytest.raises(ValueError, match="duplicate"):
+            backtest("k_rate", 2023, seasons=seasons, providers={"dup": dup})


### PR DESCRIPTION
Two things: the numbers that say where we actually stand, and the document that turns them into the system we work against.

**`docs/architecture.md` — the north star.** The model rollup as stations (A player rates → B playing time → C team run environment → D team strength → E per-game P(win) → F season sim → G odds → H site, plus **M: market**), each with its baseline, current score, status, and swap point in code. The **gate rule**: nothing is wired into production until it beats its baseline out of sample in the harness. The **objective** restated as beating the betting market's closing line, with player props as the shortest path from station A to money, a daily market-line archive as the first new station, and the ground rules (market as baseline, walk-forward only, score in money terms, sizing is part of the model) that carry unchanged to financial markets. README, roadmap, and automation docs now point at it.

**`docs/accuracy-2026.md` — the scoreboard.** Preseason 2026 projections (ours, Steamer, ZiPS, Depth Charts, Marcel) scored on the same 263 hitters against 2026 actuals: **our Bayesian components rank last among the real systems on every component and roughly tie Marcel**; Depth Charts wins everything. Per-game walk-forward backtest over 1,757 games: production strength model Brier .2478 vs .2497 for "home team always". A coin-flip control shows September playoff odds land within 1.9 pts of FanGraphs with *no model at all*, so that agreement validates plumbing, not modeling.

**Harness fairness fixes** (`src/eval/backtest.py`): common-player scoring by default, predict-year selection for multi-year projection files (the Bayesian files were being joined 5×), duplicate rejection, `frame_provider`. Three new tests; 58 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn