### PR TITLE
Backup cron slot for the nightly job + fix clipped playoff tables

### DIFF
--- a/.github/workflows/nightly-odds.yml
+++ b/.github/workflows/nightly-odds.yml
@@ -6,7 +6,11 @@ name: Nightly playoff odds
 # Bayesian refits.
 on:
   schedule:
+    # GitHub cron is best-effort: the first run fired 4h25m late. Two
+    # slots give redundancy — the script never overwrites a dated
+    # snapshot, so a second run only refreshes latest.json.
     - cron: "15 9 * * *"     # 09:15 UTC ≈ 5:15am ET, after West Coast finals
+    - cron: "45 11 * * *"    # 11:45 UTC backup
   workflow_dispatch:
 
 permissions:

--- a/public/style.css
+++ b/public/style.css
@@ -117,7 +117,8 @@ body {
   margin-left: var(--sidebar-w);
   flex: 1;
   padding: 32px 40px;
-  max-width: 1200px;
+  max-width: 1600px;
+  min-width: 0;
 }
 
 .page { display: none; }
@@ -183,6 +184,7 @@ h1 {
 
 /* ─── Grids ───────────────────────────────────────────────────── */
 .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.grid-2 > *, .grid-3 > * { min-width: 0; }   /* let grid children shrink instead of overflowing */
 .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; }
 
 /* ─── Tables ──────────────────────────────────────────────────── */
@@ -417,3 +419,10 @@ select:focus { border-color: var(--accent); }
 .bracket .bye { color: var(--green); }
 .method-note { color: var(--text-dim); font-size: 13px; line-height: 1.6; margin: 0; }
 .stale-warning { color: var(--red); font-weight: 600; }
+
+/* Odds tables scroll inside their card; leagues stack below ~1400px so
+   neither table is ever clipped by the hidden body overflow. */
+#playoffs-table-al, #playoffs-table-nl { overflow-x: auto; }
+@media (max-width: 1700px) {
+  #page-playoffs .grid-2 { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Two small production fixes.

**Nightly job: backup cron slot.** The first scheduled run (Sept 2) fired at 13:40 UTC against a 09:15 UTC cron — 4h25m late — then succeeded and committed the snapshot. GitHub's `schedule` trigger is best-effort, so this adds a second slot at 11:45 UTC. The runner never overwrites a dated snapshot (it only refreshes `latest.json` on a repeat), so a duplicate run is harmless and the archive can't silently miss a day.

**Site: playoff tables were clipped.** On the deployed site the National League table ran off the right edge with no way to scroll: the content column was capped at 1200px with body overflow hidden. Grid children can now shrink, each odds table scrolls inside its own card, the two leagues stack below 1700px, and the content cap is 1600px so both fit side by side on wide screens. Verified in headless Chromium at 1100/1400/1600/1750/1900px.

No model or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn