### PR TITLE
Station E: starting-pitcher term — Brier .2448 vs .2462 gate on the market games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 data/parquet/
 data/raw/*.parquet
 data/statcast/*.parquet
+data/cache/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@
 this is the *system* — what feeds what, where each piece stands, and the rule
 that decides when a piece is allowed into production.
 
-Last updated: Sept 1, 2026.
+Last updated: Sept 2, 2026.
 
 ## 0. The north star
 
@@ -106,7 +106,7 @@ and it must stay that way until [A]–[C] beat their baselines.
 | **B. Playing time** | PA per player, rest of season | Recent-30-day PA share | — | Not built (roadmap 1.3) | `src/sim/strength.from_run_environment` inputs |
 | **C. Team run env.** | Projected RS/G, RA/G per team from A×B | Season-to-date runs, regressed | — | Not built (roadmap 1.5) | `strength.from_run_environment(rs, ra)` |
 | **D. Team strength** | Talent win% | Every team .500 (coin flip) | Regressed Pythagenpat, 60-game ballast | **Wired, live** | `src/sim/strength.py` |
-| **E. Per-game P(win)** | Home win prob for one game | Home team always (Brier .2497) | log5 + HFA: **.2462** · Kalshi **.2416** / Polymarket **.2417** (756 games, measured — [market-benchmark-2026.md](market-benchmark-2026.md)) | Wired; no starter/lineup terms | `strength.home_win_prob` |
+| **E. Per-game P(win)** | Home win prob for one game | log5 + HFA on team strength (Brier .2462) | **+ starting pitcher: .2448** · Kalshi **.2416** / Polymarket **.2417** (756 games, measured — [market-benchmark-2026.md](market-benchmark-2026.md)) | Starter term **beats the baseline**, not yet wired into the live odds | `strength.home_win_prob`, `src/sim/starters.py` |
 | **F. Season sim** | Monte Carlo, MLB tiebreakers, bracket | — (plumbing) | Within 1.6 pts of FanGraphs; coin-flip control within 1.9 | **Wired, validated** | `src/sim/season.py`, `standings.py`, `bracket.py` |
 | **G. Odds** | P(playoffs/div/bye/pennant/WS), win bands | — | Live, 20k sims | **Wired, live** | `src/sim/odds.py` |
 | **H. Site + archive** | Landing page, dated JSON, nightly job | — | Live; first snapshot 2026-09-01 | **Wired**; nightly first run pending | `scripts/run_playoff_odds.py`, `nightly-odds.yml` |
@@ -140,7 +140,7 @@ Ordered by (expected payoff × how soon we can test it).
 | # | Pocket | Why public systems are beatable there | Test | Station |
 |---|---|---|---|---|
 | 1 | **Fix what's broken in A** | Our fits used fake ages and no pitcher effect. Refit with real ages (done in code) + pitcher random effect and re-score. If we don't reach Depth Charts we learn the structure isn't the problem. | Component MAE vs Marcel/DC on 2020–2026 | A |
-| 2 | **Per-game with starters, lineups, bullpen** | Public projection systems don't publish game odds; the market does. Team strength gets Brier .2462; both exchanges' closes get .2416–.2417 on the same 756 games. The **0.0046** between is pitcher-quality and lineup information — measured, see market-benchmark-2026.md. | Walk-forward Brier vs. market closing lines | E |
+| 2 | **Per-game with starters, lineups, bullpen** | Public projection systems don't publish game odds; the market does. Team strength gets Brier .2462; both exchanges' closes get .2416–.2417 on the same 756 games. A regressed-FIP starter term takes **0.0014 of that 0.0046** (.2448); the remaining 0.0032 is lineups, bullpen state and a better pitcher model — measured, see market-benchmark-2026.md. | Walk-forward Brier vs. market closing lines | E |
 | 3 | **Calibrated uncertainty** | Everyone publishes a point estimate. Contract valuation (Phase 6) needs a distribution; a 10th/90th band that actually covers 80% is a product no one sells. | Coverage tests (roadmap 5.7) | A, G |
 | 4 | **Statcast-informed rates** | Marcel/Steamer/ZiPS use outcomes; batted-ball and swing data lead outcomes. Our PA-level models are positioned to use them and don't yet. | Same harness, add features | A |
 | 5 | **Rookies and low-sample players** | Regression-to-mean systems are weakest exactly where hierarchical pooling (with minor-league / Statcast priors) is strongest. | Score the <200-PA-history cohort separately | A |

--- a/docs/market-benchmark-2026.md
+++ b/docs/market-benchmark-2026.md
@@ -27,6 +27,7 @@ listing reaches back to early July. Neither venue can give us April–June.
 |---|---|---|---|
 | **Kalshi close** | **0.2416** | **0.6759** | 0.537 |
 | **Polymarket close** | **0.2417** | **0.6761** | 0.531 |
+| **pythag_60_sp** (starters, new) | **0.2448** | **0.6827** | 0.533 |
 | pythag_100 | 0.2462 | 0.6854 | 0.533 |
 | pythag_60 (production) | 0.2462 | 0.6855 | 0.533 |
 | pythag_160 | 0.2464 | 0.6858 | 0.533 |
@@ -39,26 +40,79 @@ Realized home win rate on these games: 0.529. On the wider Kalshi-only
 set (876 games from 06-26) the numbers are the same to the third decimal:
 Kalshi 0.2415, pythag_60 0.2464.
 
+`pythag_60_sp` is `pythag_60` with each side's runs-allowed rate moved by how
+far its announced starting pitcher's regressed FIP sits from league average,
+over the 5.5 innings an average start covers (`src/sim/starters.py`). It is the
+same walk-forward harness: team rates from games before the date, pitcher rates
+from appearances before the date, and the same log5 + HFA conversion. On the
+full 1,773-game 2026 set (not just the 756 the exchanges priced) it scores
+0.2465 against pythag_60's 0.2478 — the same 0.0013 gain, so the result is not
+an artifact of the market subset. **Every starter slot was filled**: across
+those 1,773 games only 2 fell back to `pythag_60` for a missing probable
+(0 of the 756), and 22 of 3,546 starter slots had no prior history and were
+scored at league average.
+
 The two exchanges agree with each other closely — mean |Δ| = 0.008,
 correlation 0.991 — so the benchmark is not an artifact of one venue.
 
 ## Reading it
 
-- **The market beats us by 0.0046 Brier** (both venues). Every one of our models is a
-  team-strength number that knows nothing about who is pitching. The market's
-  last price before first pitch does. That difference is the measured size of
-  the starting-pitcher + lineup term (architecture §4, row 2) — the next
-  modeling ticket, and now it has a number to beat.
+- **The starting pitcher closes about 30% of the gap to the market.**
+  pythag_60 → pythag_60_sp is 0.2462 → 0.2448, which is 0.0014 of the 0.0046
+  that separated us from Kalshi. The market still wins by 0.0033 (t = 2.1 on
+  the paired per-game difference, so *its* remaining edge is real). Our own
+  gain is directionally consistent — 0.0014 on the 756 market games, 0.0013 on
+  all 1,773 games of 2026, 0.0004 on 2025 — but on any one of those sets it is
+  inside one standard error (t = −1.2 on the 756, −1.7 on the 1,773). Call it a
+  real term of modest and not-yet-precisely-measured size, not a solved
+  station. It clears the station E gate (§3) on the common game set; a second
+  season of exchange history is what would make the size of the win certain.
+- **The remaining 0.0033 is lineups, bullpens, and a better pitcher model.**
+  The starter term correlates 0.68 with the market's own deviation from
+  pythag_60, and regressing the market's deviation on ours gives a slope of
+  1.21 — the market moves *further* on the same games we move on, in the same
+  direction. So we are not over-reacting to pitchers; we are under-reacting,
+  and we are missing whatever else it prices (who is actually in the lineup,
+  rest and bullpen state, weather, park).
 - **Team strength does carry real information.** pythag_60 beats the
   home-constant baseline by 0.0027, and the market beats pythag_60 by 0.0046.
   So roughly 37% of the distance from "know nothing" to "the market" is
-  covered by regressed run differential alone.
-- **Calibration of pythag_60 is fine in the middle and thin at the tails**
-  (9 games below 0.40, 32 above 0.65). Any per-game model that produces
-  sharper probabilities will need those tails to be right; the market's tails
-  are where starters matter most.
+  covered by regressed run differential alone, and another ~19% by the starter.
+- **The starter term is what put probabilities in the tails.** pythag_60 put 6
+  of the 756 games below 0.40 and 26 above 0.65; pythag_60_sp puts 24 and 42
+  there, and they verify (0.373 predicted / 0.333 realized at the bottom).
+  The top bucket is the soft spot: 42 games predicted 0.683, realized 0.619 —
+  our biggest home favorites are still a little too confident.
 - **Ballast barely matters** (30–160 games all within 0.0003). The signal we
-  are missing is not in how we regress team strength.
+  were missing was not in how we regress team strength — it was that we had no
+  pitcher at all.
+
+### How the pitcher term avoids fitting the test set
+
+The pitcher rates are Marcel-standard: K, BB+HBP and HR per batter faced over
+the current season plus the two before it at 5/4/3 recency weights, regressed
+toward league average and pushed through the standard FIP coefficients
+(13/3/−2) with the constant set so a league-average arm returns league RA/9.
+Each component is regressed on its own published rate-stabilization point —
+70 batters faced for strikeouts, 170 for walks, 1300 for home runs — so home
+runs get regressed nearly twenty times harder than strikeouts, which is what
+keeps FIP's 13× home-run coefficient from turning noise into a forecast. The
+single free knob is how much harder than *reliability* a **projection** has to
+regress, since the next start also has to absorb real talent change. That
+multiplier was chosen walk-forward on **2025 only**, where the curve is flat
+for anything from 2× to 6× (all within 0.00003 Brier); 2× was taken, giving
+ballasts of 140 / 340 / 2600 batters faced. No constant was chosen by looking
+at a 2026 score.
+
+One deliberate departure from the obvious construction: the starter enters as a
+*delta* from league average applied to the team's own runs-allowed rate, not as
+`5.5/9 · FIP + 3.5/9 · team_RA`. FIP is park- and defense-neutral and team RA is
+not, so the absolute-level blend quietly regresses 61% of every team's run
+prevention toward the league mean — a Coors staff and a Petco staff both told
+they allow league-average runs for 5.5 innings. Scored, that version came in at
+0.2466, *worse* than pythag_60, and its correlation with the market's deviation
+was only 0.48 against the delta form's 0.68. The team-regression it smuggled in
+cost more than the pitcher information it added.
 
 ## What this does not yet show
 
@@ -68,3 +122,10 @@ correlation 0.991 — so the benchmark is not an artifact of one venue.
 - Anything about *money*: this is truth scoring against the market's
   probability, not simulated P&L. CLV and fill-aware ROI come after a
   model that is at least at market on Brier.
+- **A morning-of forecast.** `probablePitcher` for a past date returns the
+  pitcher who actually started, which is what the exchanges' closes knew — the
+  median Kalshi close is 15 minutes before first pitch — so the comparison is
+  fair. It is not a simulation of predicting at 9am, where late scratches would
+  cost a little.
+- **Lineups, bullpen state, park and weather** — none of them are in the model
+  yet, and the 0.0033 the market still holds is where they live.

--- a/scripts/backtest_game_odds.py
+++ b/scripts/backtest_game_odds.py
@@ -11,9 +11,13 @@ Metrics: Brier score and log loss (lower is better). Baselines:
     win_pct_log5    — raw season win% into log5 + HFA (no regression)
     pythag_60       — the production model (regressed Pythagenpat, 60 games)
     pythag_{k}      — ballast sweep to see what the data prefers
+    pythag_60_sp    — pythag_60 with each side's runs allowed re-weighted
+                      toward its announced starting pitcher (src/sim/starters)
 
 Usage:
     python scripts/backtest_game_odds.py --season 2026 --min-games 20
+    python scripts/backtest_game_odds.py --season 2026 --min-games 20 \
+        --market data/parquet/market_closes_2026.parquet
 """
 from __future__ import annotations
 
@@ -26,10 +30,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import numpy as np
 import pandas as pd
 
-from src.data.mlb_stats_api import fetch_schedule
+from src.data.mlb_stats_api import (
+    fetch_pitcher_game_logs, fetch_probables, fetch_schedule, fetch_season_pitching,
+)
+from src.sim import starters as sp_model
 from src.sim.season import from_schedule
 from src.sim.strength import HFA_PRIOR, home_win_prob, pythagenpat
 from src.sim.teams import fetch_teams
+
+SP_MODEL = "pythag_60_sp"
+SP_BALLAST_GAMES = 60.0   # the production team-strength ballast this model extends
 
 
 def team_totals(games: pd.DataFrame, team_ids) -> pd.DataFrame:
@@ -42,20 +52,29 @@ def team_totals(games: pd.DataFrame, team_ids) -> pd.DataFrame:
     return tot
 
 
-def strengths(tot: pd.DataFrame, regress_games: float) -> pd.Series:
+def team_rates(tot: pd.DataFrame, regress_games: float) -> pd.DataFrame:
+    """Runs scored/allowed per game, regressed toward league average."""
     lg_rs = tot["rs"].sum() / max(tot["g"].sum(), 1)
     lg_ra = tot["ra"].sum() / max(tot["g"].sum(), 1)
-    out = {}
-    for t, r in tot.iterrows():
-        rs_pg = (r["rs"] + regress_games * lg_rs) / (r["g"] + regress_games)
-        ra_pg = (r["ra"] + regress_games * lg_ra) / (r["g"] + regress_games)
-        out[t] = pythagenpat(rs_pg, ra_pg, 1.0)
-    return pd.Series(out)
+    return pd.DataFrame({
+        "rs_pg": (tot["rs"] + regress_games * lg_rs) / (tot["g"] + regress_games),
+        "ra_pg": (tot["ra"] + regress_games * lg_ra) / (tot["g"] + regress_games),
+    })
+
+
+def strengths(tot: pd.DataFrame, regress_games: float) -> pd.Series:
+    rates = team_rates(tot, regress_games)
+    return pd.Series({t: pythagenpat(r["rs_pg"], r["ra_pg"], 1.0)
+                      for t, r in rates.iterrows()})
 
 
 def walk_forward(completed: pd.DataFrame, team_ids, min_games: int,
-                 ballasts: list[float]) -> pd.DataFrame:
-    """One row per scored game with each model's P(home)."""
+                 ballasts: list[float], sp_ctx: dict | None = None) -> pd.DataFrame:
+    """One row per scored game with each model's P(home).
+
+    Every quantity used on a date is rebuilt from games and pitcher
+    appearances strictly before that date.
+    """
     completed = completed.sort_values("date").reset_index(drop=True)
     rows = []
     for date, day in completed.groupby("date", sort=True):
@@ -66,6 +85,7 @@ def walk_forward(completed: pd.DataFrame, team_ids, min_games: int,
         hfa_obs = (HFA_PRIOR * 2000 + before["home_win"].sum()) / (2000 + len(before))
         wp = (tot["w"] / tot["g"]).clip(0.2, 0.8)
         s_by_k = {k: strengths(tot, k) for k in ballasts}
+        sp_day = starter_day_context(tot, date, sp_ctx) if sp_ctx else None
         for g in day.itertuples(index=False):
             row = {"date": date, "game_pk": int(g.game_pk),
                    "home_id": g.home_id, "away_id": g.away_id,
@@ -74,8 +94,83 @@ def walk_forward(completed: pd.DataFrame, team_ids, min_games: int,
                    "win_pct_log5": float(home_win_prob(wp[g.home_id], wp[g.away_id], hfa_obs))}
             for k, s in s_by_k.items():
                 row[f"pythag_{int(k)}"] = float(home_win_prob(s[g.home_id], s[g.away_id], hfa_obs))
+            if sp_day is not None:
+                p_sp, flags = starter_game_prob(g, sp_day, hfa_obs)
+                row[SP_MODEL] = p_sp if p_sp is not None else row[f"pythag_{int(SP_BALLAST_GAMES)}"]
+                row.update(flags)
             rows.append(row)
     return pd.DataFrame(rows)
+
+
+# ─── station E starting-pitcher term ───
+
+def starter_day_context(tot: pd.DataFrame, date: str, sp_ctx: dict) -> dict:
+    """Everything the starter model needs for one slate, built from the past only."""
+    current = sp_model.appearances_before(sp_ctx["game_logs"], date)
+    counts = pd.concat([sp_ctx["prior_counts"], current], ignore_index=True)
+    # League rates come from the completed prior seasons only: the current-season
+    # logs we hold are starters-only, so pooling them would bias the regression
+    # target. The current run environment enters through lg_ra9, which anchors
+    # the FIP constant to season-to-date league runs per game.
+    lg = sp_ctx["league"]
+    lg_ra9 = float(tot["ra"].sum() / max(tot["g"].sum(), 1))
+    rates = sp_model.marcel_rates(counts, sp_ctx["season"], lg,
+                                  ballast=sp_ctx["ballast"])
+    return {
+        "sp_ra9": sp_model.starter_ra9_lookup(rates, lg, lg_ra9),
+        "lg_ra9": lg_ra9,
+        "team": team_rates(tot, SP_BALLAST_GAMES),
+        "probables": sp_ctx["probables"],
+        "starter_ip": sp_ctx["starter_ip"],
+    }
+
+
+def starter_game_prob(g, day: dict, hfa: float):
+    """P(home) with each side's runs allowed blended toward its starter.
+
+    Returns (probability or None when a starter is unknown, diagnostic flags).
+    """
+    sp_ids = day["probables"].get(int(g.game_pk))
+    flags = {"sp_fallback": sp_ids is None, "sp_no_history": 0}
+    if sp_ids is None:
+        return None, flags
+    team, lg_ra9 = day["team"], day["lg_ra9"]
+    strength = {}
+    for side, team_id, pid in (("home", g.home_id, sp_ids[0]),
+                               ("away", g.away_id, sp_ids[1])):
+        flags["sp_no_history"] += int(pid not in day["sp_ra9"])
+        ra9 = sp_model.blend_starter_team(day["sp_ra9"].get(pid, lg_ra9),
+                                          team.loc[team_id, "ra_pg"], lg_ra9,
+                                          starter_ip=day["starter_ip"])
+        strength[side] = pythagenpat(float(team.loc[team_id, "rs_pg"]), float(ra9), 1.0)
+    return float(home_win_prob(strength["home"], strength["away"], hfa)), flags
+
+
+def build_sp_context(season: int, scored: pd.DataFrame, ballast: float,
+                     starter_ip: float, prior_seasons: int = 2) -> dict:
+    """Fetch probables + pitcher counts once for the whole backtest.
+
+    `prior_seasons` completed seasons plus the current one are Marcel-weighted,
+    matching the 5/4/3 weights in `src.sim.starters`.
+    """
+    probables = fetch_probables(f"{season}-03-01", f"{season}-11-15")
+    probables = probables.dropna(subset=["home_sp_id", "away_sp_id"])
+    probables = probables[probables["game_pk"].isin(scored["game_pk"])]
+    pmap = {int(r.game_pk): (int(r.home_sp_id), int(r.away_sp_id))
+            for r in probables.itertuples(index=False)}
+
+    prior = pd.concat(
+        [fetch_season_pitching(y) for y in range(season - prior_seasons, season)],
+        ignore_index=True)
+    prior_counts = sp_model.normalize_counts(prior)
+
+    logs = fetch_pitcher_game_logs({p for ids in pmap.values() for p in ids}, season)
+    logs = logs[logs["game_type"] == "R"]
+    game_logs = sp_model.normalize_counts(logs)
+    game_logs["date"] = logs["date"].to_numpy()
+    return {"probables": pmap, "prior_counts": prior_counts, "game_logs": game_logs,
+            "league": sp_model.league_rates(prior_counts), "season": season,
+            "ballast": ballast, "starter_ip": starter_ip}
 
 
 def join_market(preds: pd.DataFrame, closes: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
@@ -107,6 +202,15 @@ def main() -> None:
     parser.add_argument("--min-games", type=int, default=20,
                         help="skip dates until every team has this many games")
     parser.add_argument("--ballasts", default="0,30,60,100,160")
+    parser.add_argument("--no-starters", action="store_true",
+                        help="skip the pythag_60_sp starting-pitcher model")
+    parser.add_argument("--sp-ballast", type=float, default=None,
+                        help="override the per-component regression ballasts in "
+                             "src/sim/starters with one batters-faced number "
+                             "(the defaults are stabilization points from the "
+                             "literature; nothing here is fit to this season)")
+    parser.add_argument("--starter-ip", type=float, default=sp_model.STARTER_IP,
+                        help="innings the starter is assumed to cover")
     parser.add_argument("--market", type=Path, default=None,
                         help="market_closes parquet from scripts/backfill_market_closes.py; "
                              "scores each venue's pre-game close as a model on the common games")
@@ -122,24 +226,42 @@ def main() -> None:
     scored["home_win"] = scored["home_score"] > scored["away_score"]
     scored = scored[scored["game_type"] == "R"]
 
-    preds = walk_forward(scored, teams["team_id"].to_numpy(), args.min_games, ballasts)
+    sp_ctx = None
+    if not args.no_starters:
+        sp_ctx = build_sp_context(
+            args.season, scored,
+            sp_model.BALLAST_BF if args.sp_ballast is None else args.sp_ballast,
+            args.starter_ip)
+
+    preds = walk_forward(scored, teams["team_id"].to_numpy(), args.min_games,
+                         ballasts, sp_ctx)
     models = ["home_constant", "win_pct_log5"] + [f"pythag_{int(k)}" for k in ballasts]
+    if sp_ctx is not None:
+        models.append(SP_MODEL)
     print(f"{len(preds)} games scored (from the date every team had {args.min_games}+ games)\n")
     print(score(preds, models).round(4).to_string(index=False))
+    if sp_ctx is not None:
+        print(f"\n{SP_MODEL}: {int(preds['sp_fallback'].sum())} of {len(preds)} games fell back "
+              f"to pythag_{int(SP_BALLAST_GAMES)} for a missing starter; "
+              f"{int(preds['sp_no_history'].sum())} starter slots had no history "
+              f"(scored at league average).")
 
     if args.market is not None:
         preds, market_models = join_market(preds, pd.read_parquet(args.market))
         print(f"\n{len(preds)} games also priced by every venue in {args.market.name} — "
               f"the market is the bar (docs/architecture.md §0):\n")
         print(score(preds, models + market_models).round(4).to_string(index=False))
-    # Calibration of the production model
-    prod = preds[["home_win", "pythag_60"]].copy()
-    prod["bucket"] = pd.cut(prod["pythag_60"], [0, .4, .45, .5, .55, .6, .65, 1.0])
-    cal = prod.groupby("bucket", observed=True).agg(n=("home_win", "size"),
-                                                   predicted=("pythag_60", "mean"),
-                                                   realized=("home_win", "mean"))
-    print("\nCalibration (pythag_60):")
-    print(cal.round(3).to_string())
+        if sp_ctx is not None:
+            print(f"\n  of these, {int(preds['sp_fallback'].sum())} fell back to "
+                  f"pythag_{int(SP_BALLAST_GAMES)} for a missing starter.")
+    # Calibration of the production model, and of the challenger
+    for model in ["pythag_60"] + ([SP_MODEL] if sp_ctx is not None else []):
+        buckets = pd.cut(preds[model], [0, .4, .45, .5, .55, .6, .65, 1.0])
+        cal = preds.groupby(buckets, observed=True).agg(n=("home_win", "size"),
+                                                        predicted=(model, "mean"),
+                                                        realized=("home_win", "mean"))
+        print(f"\nCalibration ({model}):")
+        print(cal.round(3).to_string())
 
 
 if __name__ == "__main__":

--- a/src/data/mlb_stats_api.py
+++ b/src/data/mlb_stats_api.py
@@ -1,27 +1,43 @@
 """MLB Stats API (statsapi.mlb.com) ingest — no credentials required.
 
-Three feeds:
+Feeds:
   * season hitting stats  → the season-level table the backtest harness scores
   * standings             → Phase 2 simulator input
   * schedule              → remaining games for the season Monte Carlo
+  * probable starters     → station E starting-pitcher term
+  * season / game-log pitching stats → the pitcher rates that term is built on
 
 Player ids are MLBAM ids, identical to Statcast `batter`, so everything joins
 to the Bayesian components and the Chadwick birthdates with no crosswalk.
 """
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 
 import pandas as pd
 import requests
 
-from src.config import PARQUET_DIR
+from src.config import DATA_DIR, PARQUET_DIR
 
 logger = logging.getLogger(__name__)
 
 BASE = "https://statsapi.mlb.com/api/v1"
 SEASONS_PARQUET = PARQUET_DIR / "hitter_seasons_api.parquet"
+# Raw API JSON lands here so a walk-forward backtest can be re-run offline.
+# Gitignored (data/cache/); delete a file or pass refresh=True to re-pull.
+STATSAPI_CACHE = DATA_DIR / "cache" / "statsapi"
+
+PITCHING_FIELDS = {
+    "battersFaced": "bf",
+    "strikeOuts": "k",
+    "baseOnBalls": "bb",
+    "hitBatsmen": "hbp",
+    "homeRuns": "hr",
+    "earnedRuns": "er",
+    "gamesStarted": "gs",
+}
 
 # Stats API field → our column
 HITTING_FIELDS = {
@@ -42,6 +58,35 @@ def _get(path: str, **params) -> dict:
     resp = requests.get(f"{BASE}/{path}", params=params, timeout=60)
     resp.raise_for_status()
     return resp.json()
+
+
+def _get_cached(cache_key: str, path: str, refresh: bool = False, **params) -> dict:
+    """`_get` with the response JSON cached under data/cache/statsapi/.
+
+    Only ever cache *settled* facts (a past date's schedule, a finished
+    appearance). Anything about a game that has not started yet will go stale.
+    """
+    cache_file = STATSAPI_CACHE / f"{cache_key}.json"
+    if cache_file.exists() and not refresh:
+        try:
+            return json.loads(cache_file.read_text())
+        except json.JSONDecodeError:
+            logger.warning(f"corrupt cache {cache_file}; re-fetching")
+    data = _get(path, **params)
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps(data))
+    return data
+
+
+def _ip_to_outs(innings) -> float:
+    """Stats API innings-pitched strings ("5.2" = 5 innings + 2 outs) → outs."""
+    if innings is None:
+        return 0.0
+    whole, _, frac = str(innings).partition(".")
+    try:
+        return float(whole or 0) * 3 + float(frac[:1] or 0)
+    except ValueError:
+        return 0.0
 
 
 def fetch_season_hitting(season: int, page_size: int = 500) -> pd.DataFrame:
@@ -143,3 +188,116 @@ def fetch_schedule(start_date: str, end_date: str) -> pd.DataFrame:
                 "away_score": g["teams"]["away"].get("score"),
             })
     return pd.DataFrame(rows)
+
+
+# ─── Station E: probable starters and pitcher rates ───
+
+def fetch_probables(start_date: str, end_date: str, refresh: bool = False) -> pd.DataFrame:
+    """One row per game_pk with the home/away starting pitcher ids.
+
+    Columns: game_pk, date, game_type, home_sp_id, away_sp_id (nullable Int64).
+
+    Walk-forward honesty: `probablePitcher` is a *pre-game* announcement field,
+    but for a date already in the past the API serves the pitcher who actually
+    started. Verified on 2026-07-18 (16/16 games match the boxscore's starter).
+    That is the same information the market had at its close, which is a median
+    15 minutes before first pitch (docs/market-benchmark-2026.md) — so scoring a
+    model that uses it against the exchanges' closes is a fair comparison. It is
+    *not* a simulation of picking games the morning before, where late scratches
+    would cost you a little.
+
+    Requests are chunked by month and cached; the API returns the whole range in
+    one call but a month is a friendlier cache unit.
+    """
+    months = pd.period_range(start=start_date, end=end_date, freq="M")
+    rows = []
+    for period in months:
+        lo = max(period.start_time.date(), pd.Timestamp(start_date).date())
+        hi = min(period.end_time.date(), pd.Timestamp(end_date).date())
+        data = _get_cached(
+            f"probables_{lo}_{hi}", "schedule", refresh=refresh,
+            sportId=1, startDate=str(lo), endDate=str(hi),
+            hydrate="probablePitcher",
+        )
+        for day in data.get("dates", []):
+            for g in day.get("games", []):
+                teams = g.get("teams", {})
+                rows.append({
+                    "game_pk": g["gamePk"],
+                    "date": day["date"],
+                    "game_type": g.get("gameType"),
+                    "home_sp_id": (teams.get("home", {}).get("probablePitcher") or {}).get("id"),
+                    "away_sp_id": (teams.get("away", {}).get("probablePitcher") or {}).get("id"),
+                })
+    df = pd.DataFrame(rows, columns=["game_pk", "date", "game_type",
+                                     "home_sp_id", "away_sp_id"])
+    for col in ("home_sp_id", "away_sp_id"):
+        df[col] = df[col].astype("Int64")
+    logger.info(f"probables {start_date}..{end_date}: {len(df)} games, "
+                f"{int((df['home_sp_id'].notna() & df['away_sp_id'].notna()).sum())} with both")
+    return df
+
+
+def fetch_season_pitching(season: int, page_size: int = 1000,
+                          refresh: bool = False) -> pd.DataFrame:
+    """Season pitching totals for every pitcher, one row per player-team split.
+
+    Columns: pitcher, season, bf, k, bb, hbp, hr, er, gs, outs.
+    """
+    rows, offset = [], 0
+    while True:
+        data = _get_cached(
+            f"pitching_season_{season}_{offset}", "stats", refresh=refresh,
+            stats="season", group="pitching", season=season, sportId=1,
+            playerPool="all", limit=page_size, offset=offset,
+        )
+        stats = data.get("stats", [])
+        splits = stats[0].get("splits", []) if stats else []
+        if not splits:
+            break
+        for s in splits:
+            row = {"pitcher": s["player"]["id"], "season": season,
+                   "outs": _ip_to_outs(s["stat"].get("inningsPitched"))}
+            for api_field, col in PITCHING_FIELDS.items():
+                row[col] = s["stat"].get(api_field, 0) or 0
+            rows.append(row)
+        offset += page_size
+        if offset >= stats[0].get("totalSplits", 0):
+            break
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return df
+    agg = df.groupby(["pitcher", "season"], as_index=False).sum(numeric_only=True)
+    logger.info(f"{season}: {len(agg)} pitcher seasons")
+    return agg
+
+
+def fetch_pitcher_game_logs(pitcher_ids, season: int,
+                            refresh: bool = False) -> pd.DataFrame:
+    """Per-appearance pitching lines for `pitcher_ids` in `season`.
+
+    Columns: pitcher, season, date, game_pk, game_type, bf, k, bb, hbp, hr,
+    er, gs, outs. One row per appearance — the caller filters to `date <` the
+    game being predicted, which is what keeps the backtest walk-forward.
+    """
+    rows = []
+    for pid in sorted({int(p) for p in pitcher_ids}):
+        data = _get_cached(
+            f"pitching_gamelog_{season}_{pid}", f"people/{pid}/stats",
+            refresh=refresh, stats="gameLog", group="pitching", season=season,
+        )
+        stats = data.get("stats", [])
+        for s in (stats[0].get("splits", []) if stats else []):
+            row = {"pitcher": pid, "season": season, "date": s.get("date"),
+                   "game_pk": (s.get("game") or {}).get("gamePk"),
+                   "game_type": s.get("gameType"),
+                   "outs": _ip_to_outs(s["stat"].get("inningsPitched"))}
+            for api_field, col in PITCHING_FIELDS.items():
+                row[col] = s["stat"].get(api_field, 0) or 0
+            rows.append(row)
+    cols = ["pitcher", "season", "date", "game_pk", "game_type", "outs",
+            *PITCHING_FIELDS.values()]
+    df = pd.DataFrame(rows, columns=cols)
+    logger.info(f"{season} game logs: {len(df)} appearances "
+                f"for {df['pitcher'].nunique() if len(df) else 0} pitchers")
+    return df

--- a/src/sim/starters.py
+++ b/src/sim/starters.py
@@ -1,0 +1,227 @@
+"""Starting-pitcher rates for station E (per-game P(win)).
+
+The production per-game model (`strength.py`) knows only team run
+differential; the market's pre-first-pitch price knows who is on the mound.
+That gap is worth 0.0046 Brier (docs/market-benchmark-2026.md). This module
+is the first term aimed at it.
+
+The chain, all pure functions over DataFrames so it unit-tests without a
+network:
+
+    season/game-log counts ─► marcel_rates()  Marcel-weighted, league-regressed
+                                              K, BB+HBP, HR per batter faced
+                             ─► fip_ra9()     FIP coefficients → runs per 9,
+                                              re-centred so a league-average
+                                              pitcher gives league RA/9
+                             ─► blend_starter_team()  the team's runs-allowed
+                                              rate, moved by how far this
+                                              starter is from league average
+                                              over the ~5.5 innings he covers
+
+The output is a runs-allowed-per-9 number that drops straight into the
+existing Pythagenpat → log5 → HFA pipeline in place of the team's RA/G.
+`scripts/backtest_game_odds.py` scores it as `pythag_60_sp`.
+
+Every constant below comes from outside the test set: Marcel's published
+recency weights, the standard FIP coefficients, published rate-stabilization
+points for the ballasts, 5.5 innings for an average start. The one free knob
+(how much harder than reliability to regress) was chosen on the 2025 season,
+walk-forward, and the 2025 curve is flat over the whole plausible range.
+Nothing here is fit to the 2026 games this model is scored on.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# Marcel's recency weights: current season, one back, two back.
+MARCEL_WEIGHTS = (5.0, 4.0, 3.0)
+# Published stabilization points for pitcher rate stats: the sample at which
+# split-half correlation reaches 0.5, which is exactly a regression ballast.
+# The ordering is the whole point — strikeouts are nearly real on sight, walks
+# take a couple of months, and home-run rate stays mostly noise for years,
+# which matters because FIP puts a 13x coefficient on it.
+STABILIZATION_BF = {"k": 70.0, "bbhbp": 170.0, "hr": 1300.0}
+# Those points measure reliability (how much of *this* sample is signal).
+# Projecting the *next* start also has to absorb real talent change between
+# samples, so projection systems regress harder than reliability alone implies;
+# roughly double is the conventional rule of thumb. Walk-forward on the 2025
+# season agrees and is flat for anything above it (2.0/3.0/4.0/6.0 all land
+# within 0.00003 Brier of each other), so nothing hinges on the exact value.
+# Chosen on 2025 only — never on the games this model is scored against.
+PROJECTION_MULTIPLIER = 2.0
+BALLAST_BF = {c: v * PROJECTION_MULTIPLIER for c, v in STABILIZATION_BF.items()}
+# Standard FIP coefficients on HR, BB+HBP and K. They are applied per *inning*
+# — FIP = (13·HR + 3·(BB+HBP) − 2·K)/IP + C — and the constant is what puts the
+# result on a per-nine-innings run scale.
+FIP_COEF = {"hr": 13.0, "bbhbp": 3.0, "k": -2.0}
+# Below this a "runs allowed per 9" is a data error, not a projection, and
+# Pythagenpat would go complex on a non-positive rate. Never binds in practice.
+MIN_RA9 = 0.5
+# Innings the average start covers; the bullpen takes the other 3.5.
+STARTER_IP = 5.5
+GAME_IP = 9.0
+
+COMPONENTS = ("k", "bbhbp", "hr")
+RATE_COLS = [f"rate_{c}" for c in COMPONENTS]
+
+
+def normalize_counts(df: pd.DataFrame) -> pd.DataFrame:
+    """Pitcher count frame → the columns this module works in.
+
+    Accepts the raw Stats API column names (`bf, k, bb, hbp, hr, outs`) and
+    returns `pitcher, season, bf, k, bbhbp, hr, outs`. Walks are folded
+    together with hit batsmen because FIP treats them identically.
+    """
+    def col(name: str) -> pd.Series:
+        if name not in df.columns:
+            return pd.Series(0.0, index=df.index, dtype=float)
+        return pd.to_numeric(df[name], errors="coerce").fillna(0.0).astype(float)
+
+    out = pd.DataFrame({
+        "pitcher": df["pitcher"].astype("int64"),
+        "season": df["season"].astype("int64"),
+        "bf": col("bf"), "k": col("k"), "bbhbp": col("bb") + col("hbp"),
+        "hr": col("hr"), "outs": col("outs"),
+    })
+    return out[["pitcher", "season", "bf", "k", "bbhbp", "hr", "outs"]]
+
+
+def league_rates(counts: pd.DataFrame) -> dict:
+    """Pooled league rates per batter faced, plus batters faced per 9 innings.
+
+    Keys: rate_k, rate_bbhbp, rate_hr, bf_per_ip.
+    """
+    bf = float(counts["bf"].sum())
+    outs = float(counts["outs"].sum())
+    if bf <= 0:
+        raise ValueError("league_rates: no batters faced in the counts frame")
+    lg = {f"rate_{c}": float(counts[c].sum()) / bf for c in COMPONENTS}
+    # Three outs to an inning; fall back to the modern ~4.3 if outs are absent.
+    lg["bf_per_ip"] = 3.0 * bf / outs if outs > 0 else 4.3
+    return lg
+
+
+def appearances_before(game_logs: pd.DataFrame, as_of: str) -> pd.DataFrame:
+    """Season-to-date counts per pitcher from appearances *strictly before* `as_of`.
+
+    This is the leakage guard: an appearance on the game's own date (the start
+    being predicted, or an earlier game of a doubleheader that has not been
+    played when the line is priced) never contributes to the rates used to
+    predict it.
+    """
+    cols = ["pitcher", "season", "bf", "k", "bbhbp", "hr", "outs"]
+    if game_logs.empty:
+        return pd.DataFrame(columns=cols)
+    past = game_logs[game_logs["date"].astype(str) < str(as_of)]
+    if past.empty:
+        return pd.DataFrame(columns=cols)
+    return (past.groupby(["pitcher", "season"], as_index=False)[
+        ["bf", "k", "bbhbp", "hr", "outs"]].sum())
+
+
+def _ballast_map(ballast) -> dict:
+    """A scalar applies to every component; a mapping is used as given."""
+    if isinstance(ballast, dict):
+        return {c: float(ballast[c]) for c in COMPONENTS}
+    return {c: float(ballast) for c in COMPONENTS}
+
+
+def marcel_rates(counts: pd.DataFrame, as_of_season: int, lg: dict,
+                 weights: tuple = MARCEL_WEIGHTS,
+                 ballast=BALLAST_BF) -> pd.DataFrame:
+    """Per-pitcher K, BB+HBP and HR rates per batter faced.
+
+    `counts` holds one row per pitcher-season (normalize_counts schema) and may
+    mix the partial current season with completed prior ones. Seasons are
+    weighted by recency — `weights[i]` for `as_of_season - i` — normalised so
+    the most recent weight is 1, so `ballast` is denominated in real batters
+    faced. `ballast` is either one number for all three components or a
+    {component: batters faced} mapping (the default, `BALLAST_BF`).
+
+    Returns a frame indexed by pitcher with rate_k, rate_bbhbp, rate_hr and
+    `bf_weighted` (the effective sample behind those rates). A pitcher with no
+    history is simply absent — `starter_ra9_lookup` gives those league average.
+    """
+    w = {as_of_season - i: weights[i] / weights[0] for i in range(len(weights))}
+    used = counts[counts["season"].isin(w)].copy()
+    if used.empty:
+        return pd.DataFrame(columns=["bf_weighted", *RATE_COLS],
+                            index=pd.Index([], name="pitcher", dtype="int64"))
+    ws = used["season"].map(w).astype(float)
+    for col in ("bf", *COMPONENTS):
+        used[col] = used[col].astype(float) * ws
+    agg = used.groupby("pitcher")[["bf", *COMPONENTS]].sum()
+    bal = _ballast_map(ballast)
+    out = pd.DataFrame(index=agg.index)
+    out["bf_weighted"] = agg["bf"]
+    for c in COMPONENTS:
+        out[f"rate_{c}"] = ((agg[c] + bal[c] * lg[f"rate_{c}"])
+                            / (agg["bf"] + bal[c]))
+    return out
+
+
+def fip_constant(lg: dict, lg_ra9: float) -> float:
+    """Additive constant putting FIP on the league's runs-allowed-per-9 scale.
+
+    Standard FIP is calibrated so league FIP = league ERA; here we calibrate to
+    league RA/9 instead, because the team number this blends with (station D's
+    regressed runs allowed per game) includes unearned runs.
+    """
+    return float(lg_ra9) - _fip_core(lg, lg["bf_per_ip"])
+
+
+def _fip_core(rates, bf_per_ip: float):
+    """(13·HR + 3·(BB+HBP) − 2·K) / IP, from per-batter-faced rates."""
+    per_bf = sum(FIP_COEF[c] * rates[f"rate_{c}"] for c in COMPONENTS)
+    return per_bf * bf_per_ip
+
+
+def fip_ra9(rates: pd.DataFrame, lg: dict, lg_ra9: float) -> pd.Series:
+    """Per-pitcher FIP expressed as runs allowed per 9 innings.
+
+    A pitcher whose rates equal the league's scores exactly `lg_ra9`, so the
+    starter term only ever *re-allocates* runs around the team baseline — it
+    cannot silently shift the whole league's run environment.
+    """
+    if rates.empty:
+        return pd.Series(dtype=float, name="sp_ra9")
+    core = _fip_core(rates, lg["bf_per_ip"])
+    ra9 = (core + fip_constant(lg, lg_ra9)).clip(lower=MIN_RA9)
+    return pd.Series(ra9, index=rates.index, name="sp_ra9").astype(float)
+
+
+def blend_starter_team(sp_ra9, team_ra9, lg_ra9, starter_ip: float = STARTER_IP,
+                       game_ip: float = GAME_IP):
+    """Expected runs allowed per 9 with this starter in front of this staff.
+
+        team_ra9 + w · (sp_ra9 − lg_ra9),   w = starter_ip / game_ip
+
+    i.e. the team's own (already regressed) runs-allowed rate, moved by the
+    starter's *deviation from a league-average starter*, weighted by the share
+    of the game he is expected to cover.
+
+    Why a delta rather than the more obvious `w·sp_ra9 + (1−w)·team_ra9`: FIP
+    is park- and defense-neutral, while team RA/9 is not. Mixing them on
+    absolute levels quietly drags 61% of every team's run prevention back to
+    the league mean — a Coors staff and a Petco staff would both be told they
+    allow league-average runs for 5.5 innings — which is a *team* regression
+    wearing a pitcher's uniform, and it costs more than the pitcher signal
+    gains. In delta form a league-average starter leaves the team's number
+    exactly where station D put it, so the term can only ever add pitcher
+    information. Park, defense and framing stay in `team_ra9`, where they were
+    measured.
+
+    Using the team's own rate for the relief innings rather than a separate
+    bullpen number keeps v1 to one new moving part.
+
+    Scalars or aligned arrays.
+    """
+    w = float(starter_ip) / float(game_ip)
+    return np.asarray(team_ra9, dtype=float) + w * (
+        np.asarray(sp_ra9, dtype=float) - np.asarray(lg_ra9, dtype=float))
+
+
+def starter_ra9_lookup(rates: pd.DataFrame, lg: dict, lg_ra9: float) -> dict:
+    """{pitcher_id: FIP runs/9}. Missing ids fall back to `lg_ra9` at lookup."""
+    return {int(k): float(v) for k, v in fip_ra9(rates, lg, lg_ra9).items()}

--- a/tests/test_sim/test_starters.py
+++ b/tests/test_sim/test_starters.py
@@ -1,0 +1,280 @@
+"""Unit tests for the station E starting-pitcher term (src/sim/starters.py).
+
+All synthetic — no network. What has to hold:
+  * rates regress toward league average, harder for small samples
+  * recent seasons outweigh old ones (Marcel 5/4/3)
+  * a pitcher with no history scores exactly league average
+  * the game-level blend weights the starter by his share of the innings
+  * appearances on or after the game date never enter the rates (leakage)
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.sim import starters as st
+
+# A tidy league: 1000 BF, 22% K, 8% BB+HBP, 3% HR, 27 outs per 38.5 BF.
+LEAGUE = {"rate_k": 0.22, "rate_bbhbp": 0.08, "rate_hr": 0.03, "bf_per_ip": 4.28}
+LG_RA9 = 4.50
+
+
+def counts(pitcher, season, bf, k, bbhbp, hr, outs=None):
+    return {"pitcher": pitcher, "season": season, "bf": bf, "k": k,
+            "bbhbp": bbhbp, "hr": hr, "outs": outs if outs is not None else bf * 0.7}
+
+
+def frame(rows):
+    return pd.DataFrame(rows)
+
+
+# ─── normalize_counts ───
+
+def test_normalize_counts_folds_walks_and_hbp():
+    raw = pd.DataFrame([{"pitcher": 1, "season": 2025, "bf": 100, "k": 25,
+                         "bb": 7, "hbp": 2, "hr": 3, "outs": 70}])
+    out = st.normalize_counts(raw)
+    assert list(out.columns) == ["pitcher", "season", "bf", "k", "bbhbp", "hr", "outs"]
+    assert out.loc[0, "bbhbp"] == 9.0
+
+
+def test_normalize_counts_tolerates_missing_hbp_and_outs():
+    raw = pd.DataFrame([{"pitcher": 1, "season": 2025, "bf": 100, "k": 25,
+                         "bb": 7, "hr": 3}])
+    out = st.normalize_counts(raw)
+    assert out.loc[0, "bbhbp"] == 7.0
+    assert out.loc[0, "outs"] == 0.0
+
+
+# ─── league_rates ───
+
+def test_league_rates_are_pooled_per_batter_faced():
+    lg = st.league_rates(frame([counts(1, 2025, 1000, 250, 80, 30, outs=700),
+                                counts(2, 2025, 1000, 190, 80, 30, outs=700)]))
+    assert lg["rate_k"] == pytest.approx(0.22)
+    assert lg["rate_bbhbp"] == pytest.approx(0.08)
+    assert lg["rate_hr"] == pytest.approx(0.03)
+    assert lg["bf_per_ip"] == pytest.approx(3 * 2000 / 1400)
+
+
+def test_league_rates_rejects_empty_pool():
+    with pytest.raises(ValueError):
+        st.league_rates(frame([counts(1, 2025, 0, 0, 0, 0, outs=0)]))
+
+
+# ─── marcel_rates: regression toward the league ───
+
+def test_small_sample_is_pulled_further_toward_league_than_large_sample():
+    """Same rate, different sample: the 100-BF pitcher lands closer to league."""
+    small = st.marcel_rates(frame([counts(1, 2026, 100, 40, 8, 3)]), 2026, LEAGUE, ballast=200)
+    big = st.marcel_rates(frame([counts(1, 2026, 1000, 400, 80, 30)]), 2026, LEAGUE, ballast=200)
+    lg_k = LEAGUE["rate_k"]
+    assert lg_k < small.loc[1, "rate_k"] < big.loc[1, "rate_k"]
+    # ballast 200 against 100 BF → two-thirds league, one-third the pitcher
+    assert small.loc[1, "rate_k"] == pytest.approx((40 + 200 * lg_k) / 300)
+
+
+def test_home_runs_are_regressed_far_harder_than_strikeouts():
+    """FIP's 13x coefficient sits on the noisiest component; the default
+    ballasts are what stop it from dominating."""
+    df = frame([counts(1, 2026, 600, 300, 24, 30)])   # elite K, double the HR
+    rates = st.marcel_rates(df, 2026, LEAGUE)
+    k_pull = (rates.loc[1, "rate_k"] - LEAGUE["rate_k"]) / (0.5 - LEAGUE["rate_k"])
+    hr_pull = (rates.loc[1, "rate_hr"] - LEAGUE["rate_hr"]) / (0.05 - LEAGUE["rate_hr"])
+    assert k_pull > 0.75
+    assert hr_pull < 0.25
+    assert k_pull > 3 * hr_pull
+
+
+def test_a_scalar_ballast_applies_to_every_component():
+    rates = st.marcel_rates(frame([counts(1, 2026, 100, 40, 8, 3)]), 2026,
+                            LEAGUE, ballast=100)
+    for c in st.COMPONENTS:
+        own = {"k": 0.40, "bbhbp": 0.08, "hr": 0.03}[c]
+        assert rates.loc[1, f"rate_{c}"] == pytest.approx(
+            (100 * own + 100 * LEAGUE[f"rate_{c}"]) / 200)
+
+
+def test_zero_batters_faced_gives_exactly_league_average():
+    rates = st.marcel_rates(frame([counts(1, 2026, 0, 0, 0, 0)]), 2026, LEAGUE)
+    for c in st.COMPONENTS:
+        assert rates.loc[1, f"rate_{c}"] == pytest.approx(LEAGUE[f"rate_{c}"])
+
+
+def test_ballast_size_controls_how_hard_we_regress():
+    df = frame([counts(1, 2026, 400, 160, 32, 12)])
+    light = st.marcel_rates(df, 2026, LEAGUE, ballast=50)
+    heavy = st.marcel_rates(df, 2026, LEAGUE, ballast=800)
+    assert light.loc[1, "rate_k"] > heavy.loc[1, "rate_k"] > LEAGUE["rate_k"]
+
+
+# ─── marcel_rates: recency weighting ───
+
+def test_recent_season_outweighs_older_ones():
+    """Identical samples, opposite signal: whichever is recent wins."""
+    good_now = st.marcel_rates(frame([counts(1, 2026, 500, 150, 40, 15),
+                                      counts(1, 2024, 500, 50, 40, 15)]), 2026, LEAGUE)
+    good_then = st.marcel_rates(frame([counts(1, 2026, 500, 50, 40, 15),
+                                       counts(1, 2024, 500, 150, 40, 15)]), 2026, LEAGUE)
+    assert good_now.loc[1, "rate_k"] > good_then.loc[1, "rate_k"]
+
+
+def test_weights_are_five_four_three_normalized_to_the_current_season():
+    rates = st.marcel_rates(frame([counts(1, 2026, 100, 30, 8, 3),
+                                   counts(1, 2025, 100, 20, 8, 3),
+                                   counts(1, 2024, 100, 10, 8, 3)]), 2026,
+                            LEAGUE, ballast=200)
+    w = [1.0, 0.8, 0.6]
+    num = 30 * w[0] + 20 * w[1] + 10 * w[2] + 200 * LEAGUE["rate_k"]
+    den = 100 * sum(w) + 200
+    assert rates.loc[1, "rate_k"] == pytest.approx(num / den)
+    assert rates.loc[1, "bf_weighted"] == pytest.approx(100 * sum(w))
+
+
+def test_seasons_outside_the_three_year_window_are_ignored():
+    with_old = st.marcel_rates(frame([counts(1, 2026, 200, 60, 16, 6),
+                                      counts(1, 2019, 900, 400, 16, 6)]), 2026, LEAGUE)
+    without = st.marcel_rates(frame([counts(1, 2026, 200, 60, 16, 6)]), 2026, LEAGUE)
+    assert with_old.loc[1, "rate_k"] == pytest.approx(without.loc[1, "rate_k"])
+
+
+def test_pitcher_with_no_rows_at_all_is_absent_from_the_table():
+    rates = st.marcel_rates(frame([counts(1, 2026, 200, 60, 16, 6)]), 2026, LEAGUE)
+    assert 2 not in rates.index
+    assert st.marcel_rates(frame([counts(1, 2019, 200, 60, 16, 6)]), 2026, LEAGUE).empty
+
+
+# ─── fip_ra9: league average in, league RA/9 out ───
+
+def test_league_average_pitcher_scores_exactly_league_ra9():
+    rates = pd.DataFrame([{f"rate_{c}": LEAGUE[f"rate_{c}"] for c in st.COMPONENTS}],
+                         index=pd.Index([1], name="pitcher"))
+    assert st.fip_ra9(rates, LEAGUE, LG_RA9).loc[1] == pytest.approx(LG_RA9)
+
+
+def test_missing_pitcher_falls_back_to_league_average():
+    lookup = st.starter_ra9_lookup(
+        st.marcel_rates(frame([counts(1, 2026, 500, 150, 30, 10)]), 2026, LEAGUE),
+        LEAGUE, LG_RA9)
+    assert 1 in lookup
+    assert lookup.get(999, LG_RA9) == pytest.approx(LG_RA9)
+
+
+def test_strikeouts_lower_and_homers_raise_the_run_estimate():
+    def ra9(k, bbhbp, hr):
+        rates = pd.DataFrame([{"rate_k": k, "rate_bbhbp": bbhbp, "rate_hr": hr}],
+                             index=pd.Index([1], name="pitcher"))
+        return st.fip_ra9(rates, LEAGUE, LG_RA9).loc[1]
+
+    base = ra9(**{k.replace("rate_", ""): LEAGUE[k] for k in
+                  ("rate_k", "rate_bbhbp", "rate_hr")})
+    assert ra9(0.30, 0.08, 0.03) < base          # more strikeouts → fewer runs
+    assert ra9(0.22, 0.08, 0.05) > base          # more homers → more runs
+    assert ra9(0.22, 0.12, 0.03) > base          # more free passes → more runs
+
+
+def test_fip_coefficients_are_the_standard_thirteen_three_minus_two():
+    lg = dict(LEAGUE)
+    rates = pd.DataFrame([{"rate_k": 0.22, "rate_bbhbp": 0.08, "rate_hr": 0.04}],
+                         index=pd.Index([1], name="pitcher"))
+    delta = st.fip_ra9(rates, lg, LG_RA9).loc[1] - LG_RA9
+    assert delta == pytest.approx(13.0 * 0.01 * lg["bf_per_ip"])
+
+
+# ─── blend_starter_team ───
+
+def test_league_average_starter_leaves_the_team_baseline_untouched():
+    """The property the whole design turns on: no pitcher signal, no change."""
+    for team_ra in (3.6, 4.5, 5.4):
+        assert st.blend_starter_team(LG_RA9, team_ra, LG_RA9) == pytest.approx(team_ra)
+
+
+def test_starter_moves_the_team_by_his_share_of_the_innings():
+    assert st.blend_starter_team(3.5, 4.0, LG_RA9, starter_ip=5.5) == pytest.approx(
+        4.0 + 5.5 / 9 * (3.5 - LG_RA9))
+
+
+def test_a_good_starter_lowers_and_a_bad_one_raises_expected_runs():
+    assert st.blend_starter_team(3.0, 4.0, LG_RA9) < 4.0
+    assert st.blend_starter_team(6.0, 4.0, LG_RA9) > 4.0
+
+
+def test_team_context_survives_the_adjustment():
+    """A good staff behind a league-average arm stays a good staff — the
+    absolute-level blend this replaced would have dragged it to the mean."""
+    good, bad = 3.6, 5.4
+    assert st.blend_starter_team(LG_RA9, good, LG_RA9) < st.blend_starter_team(
+        LG_RA9, bad, LG_RA9)
+    # and the gap is preserved exactly, not compressed
+    assert (st.blend_starter_team(4.0, bad, LG_RA9)
+            - st.blend_starter_team(4.0, good, LG_RA9)) == pytest.approx(bad - good)
+
+
+def test_blend_endpoints():
+    assert st.blend_starter_team(3.0, 5.0, LG_RA9, starter_ip=0.0) == pytest.approx(5.0)
+    assert st.blend_starter_team(3.0, 5.0, LG_RA9, starter_ip=9.0) == pytest.approx(
+        5.0 + (3.0 - LG_RA9))
+
+
+def test_blend_is_vectorized():
+    out = st.blend_starter_team(np.array([3.0, 6.0]), np.array([4.5, 4.5]), LG_RA9)
+    assert out.shape == (2,)
+    assert out[0] < 4.5 < out[1]
+
+
+# ─── appearances_before: the leakage guard ───
+
+def logs():
+    return pd.DataFrame([
+        {"pitcher": 1, "season": 2026, "date": "2026-04-01", "bf": 20,
+         "k": 6, "bbhbp": 2, "hr": 1, "outs": 15},
+        {"pitcher": 1, "season": 2026, "date": "2026-04-07", "bf": 25,
+         "k": 9, "bbhbp": 1, "hr": 0, "outs": 18},
+        {"pitcher": 1, "season": 2026, "date": "2026-04-13", "bf": 30,
+         "k": 12, "bbhbp": 3, "hr": 2, "outs": 21},
+    ])
+
+
+def test_only_appearances_strictly_before_the_date_are_counted():
+    before = st.appearances_before(logs(), "2026-04-13")
+    assert before.loc[0, "bf"] == 45          # first two starts only
+    assert before.loc[0, "k"] == 15
+
+
+def test_the_start_being_predicted_is_excluded():
+    """The 04-13 line must not feed the 04-13 prediction."""
+    on_the_day = st.appearances_before(logs(), "2026-04-13")
+    day_after = st.appearances_before(logs(), "2026-04-14")
+    assert day_after.loc[0, "bf"] == 75
+    assert on_the_day.loc[0, "bf"] < day_after.loc[0, "bf"]
+
+
+def test_future_appearances_never_leak_into_the_rates():
+    early = st.marcel_rates(st.appearances_before(logs(), "2026-04-07"), 2026, LEAGUE)
+    late = st.marcel_rates(st.appearances_before(logs(), "2026-04-20"), 2026, LEAGUE)
+    assert early.loc[1, "bf_weighted"] == pytest.approx(20)
+    assert late.loc[1, "bf_weighted"] == pytest.approx(75)
+
+
+def test_no_appearances_yet_yields_an_empty_frame():
+    empty = st.appearances_before(logs(), "2026-03-01")
+    assert empty.empty
+    assert st.marcel_rates(empty, 2026, LEAGUE).empty
+    assert st.appearances_before(pd.DataFrame(), "2026-05-01").empty
+
+
+def test_opening_day_starter_with_prior_seasons_still_gets_a_rate():
+    """No 2026 log yet, but 2025/2024 carry him — this is the walk-forward
+    case on the first date of the season."""
+    prior = frame([counts(1, 2025, 600, 180, 48, 18),
+                   counts(1, 2024, 600, 180, 48, 18)])
+    pool = pd.concat([prior, st.appearances_before(logs(), "2026-03-01")],
+                     ignore_index=True)
+    rates = st.marcel_rates(pool, 2026, LEAGUE)
+    assert rates.loc[1, "bf_weighted"] == pytest.approx(600 * 0.8 + 600 * 0.6)
+
+
+def test_absurd_rates_are_clamped_to_a_positive_run_rate():
+    """Pythagenpat needs RA/9 > 0; a nonsense line must not produce a negative."""
+    rates = pd.DataFrame([{"rate_k": 0.95, "rate_bbhbp": 0.0, "rate_hr": 0.0}],
+                         index=pd.Index([1], name="pitcher"))
+    assert st.fip_ra9(rates, LEAGUE, LG_RA9).loc[1] == pytest.approx(st.MIN_RA9)


### PR DESCRIPTION
BAS-35 / #10. First bottom-up term in the per-game model: the game's probability now depends on who is pitching. Implemented by an Opus subagent against a fixed spec and gate; reviewed and reproduced here.

## Result — 756 games priced by both exchanges, 2026-07-04 → 09-02

| model | Brier | log loss |
|---|---|---|
| Kalshi close | 0.2416 | 0.6759 |
| Polymarket close | 0.2417 | 0.6761 |
| **pythag_60_sp (new)** | **0.2448** | **0.6827** |
| pythag_60 (production, the gate) | 0.2462 | 0.6855 |
| home_constant | 0.2489 | 0.6909 |

Clears the gate by 0.0014 — about 30% of the 0.0046 that separated us from the market. Same 0.0013 gain on the full 1,773-game 2026 set (0.2465 vs 0.2478), so it is not an artifact of the market subset. 0 of the 756 games lacked a starter.

## How it works

`src/sim/starters.py`, pure functions over DataFrames:

1. **Pitcher rates** — K, BB+HBP, HR per batter faced, Marcel-weighted over the current season and two prior (5/4/3), each regressed toward league on its own published stabilization point (70 / 170 / 1300 BF). That ordering is the whole point: FIP puts a 13× coefficient on the noisiest component.
2. **FIP → runs/9**, re-centred so a league-average arm returns league RA/9.
3. **Per game** — the team's runs-allowed rate is moved by the starter's delta from league over the 5.5 innings an average start covers; bullpen keeps the team rate. Then the existing Pythagenpat → log5 → HFA pipeline unchanged.

Two things the subagent found that changed the design, both worth knowing:
- The spec's blend form `w·FIP + (1−w)·team_RA` scores **0.2466 — worse than no pitcher**. FIP is park/defense-neutral and team RA is not, so blending absolute levels regresses 61% of every team's run prevention to the mean. The delta form fixes it: a league-average starter leaves station D's number untouched.
- A single 200-BF ballast is far too light for HR. Per-component ballasts at stabilization points, times one projection multiplier chosen **walk-forward on 2025 only** (flat from 2× to 6×, all within 0.00003 Brier). No constant was picked off a 2026 score.

## Leakage discipline

- Pitcher rates from appearances **strictly before** the game date (`appearances_before`, unit-tested, doubleheader-safe).
- Team rates from games before the date; league regression targets from completed prior seasons.
- `probablePitcher` on a past date returns the actual starter, so there is no late-scratch penalty. That is what the exchanges' close (median 15 min pre-pitch) also knew, so the comparison is fair — but it is *not* a morning-of forecast. Documented in the fetcher.

## Honest read on significance

The market's remaining 0.0033 edge is significant (paired t = 2.1). Our 0.0014 gain is consistent in sign and size across three sets (756 market games, 1,773 full-season, 2025) but inside one SE on each (t = −1.2 / −1.7 / −0.6). Regressing the market's deviation from pythag_60 on ours gives slope 1.21: we under-react to starters rather than over-react, and we are missing lineups, bullpen state, and whatever else the market prices. The top bucket is the soft spot (42 games predicted 0.683, realized 0.619). All of this is in `docs/market-benchmark-2026.md`.

## Files

- Added: `src/sim/starters.py`, `tests/test_sim/test_starters.py` (29 tests)
- Changed: `src/data/mlb_stats_api.py` (`fetch_probables`, `fetch_season_pitching`, `fetch_pitcher_game_logs`, on-disk cache under `data/cache/`, gitignored), `scripts/backtest_game_odds.py` (`pythag_60_sp`, `--no-starters` / `--sp-ballast` / `--starter-ip`, sp calibration block), `docs/market-benchmark-2026.md`, `docs/architecture.md` §2 E row and §4.

Suite: 139 passed (110 + 29). Result reproduced in this session from a fresh run of the backtest.

## Not in this PR

Wiring `pythag_60_sp` into the nightly playoff-odds simulation. The gate rule says it qualifies; that is a small follow-up once this lands, since the simulator needs probable starters for *future* games (Stats API posts them ~1–2 days out; beyond that, rotation-order fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_