### PR TITLE
Intra-season walk-forward harness — in-season data is worth more than our model

### DIFF
--- a/docs/backtest-baselines.md
+++ b/docs/backtest-baselines.md
@@ -1,5 +1,9 @@
 # Baseline Backtest Scores (roadmap 0.3, baseline half)
 
+Two halves: **season-level** splits (below) and the **intra-season
+walk-forward** at date cutoffs ([jump](#intra-season-walk-forward--rest-of-2026-rates)),
+which is the one that judges rest-of-season projections.
+
 **Run:** Sept 1, 2026 · **Data:** MLB Stats API season hitting totals 2015–2026
 (`data/parquet/hitter_seasons_api.parquet`, MLBAM-keyed, rebuildable via
 `src/data/mlb_stats_api.py`) · **Method:** `scripts/run_backtest.py --sweep`,
@@ -50,3 +54,144 @@ principled it looks. Log loss is per-trial binomial NLL; MAE/RMSE are on rates.
 - 2020 (60 games) thins the ≥100-trials pool for the 2019→2020 split.
 - Ages here are the Stats API's seasonal age; components use Chadwick
   birthdates (roadmap 0.1) — identical convention (June 30).
+
+---
+
+# Intra-season walk-forward — rest-of-2026 rates
+
+**Run:** Sept 2, 2026 · **Data:** PA-level 2026 outcomes
+(`pa_outcomes/pa_outcomes_2026.parquet` in R2, 157,749 PA through Sept 1)
+aggregated to the season schema either side of each cutoff, plus 2015–2025
+season totals from `data/parquet/hitter_seasons_api.parquet` ·
+**Method:** `python scripts/run_intraseason_backtest.py`, three cutoffs,
+scored on players with ≥ 100 realized trials *after* the cutoff,
+trials-weighted, common players across all six arms.
+
+The season-level table above answers "given everything through 2025, how good
+is 2026?". The product is a **rest-of-season** projection, so the question that
+matters is "given everything through July 1, how good is the rest of 2026?"
+Training is the prior full seasons plus the current season **through the
+cutoff**; the realized side is every PA **on or after** it. The leakage guard
+(`assert_split_clean`) rejects any training PA dated on/after the cutoff and
+any realized PA before it.
+
+## The arms
+
+| Arm | Sees 2026? | What it is |
+|---|---|---|
+| `marcel` | **yes** | 5/4/3 with the partial 2026 as the most recent year. Marcel weights by trials, so a 300-PA partial season scales itself down automatically. |
+| `marcel_preseason` | no | The same Marcel with the partial season withheld — the control. `marcel` − `marcel_preseason` **is** the value of in-season information, with the model held fixed. |
+| `season_to_date` | **yes** | The player's own 2026 rate regressed to league with the component's stabilization-point ballast (K% 60 PA, BB% 120, HR 170, ISO 160 AB, BABIP 820 BIP). The "just use this year" arm. |
+| `bayes_preseason` | no | Our Bayesian components (`data/projections/*_projections_2026.parquet`), fit through 2025 and generated Apr 10 — the same file at every cutoff. |
+| `previous_season` | no | 2025 rate, unregressed. |
+| `league_average` | **yes** | League rate through the cutoff. |
+
+## MAE by component and cutoff (bold = best arm at that cutoff)
+
+| Component | Arm | May 1 | Jul 1 | Aug 1 |
+|---|---|---|---|---|
+| **k_rate** | marcel | **.0278** | **.0296** | **.0343** |
+| | marcel_preseason | .0293 | .0310 | .0365 |
+| | season_to_date | .0355 | .0340 | .0371 |
+| | bayes_preseason | .0296 | .0325 | .0386 |
+| | previous_season | .0319 | .0342 | .0363 |
+| | league_average | .0507 | .0518 | .0588 |
+| **bb_rate** | marcel | **.0172** | **.0206** | **.0268** |
+| | marcel_preseason | .0179 | .0218 | .0275 |
+| | season_to_date | .0224 | .0225 | .0280 |
+| | bayes_preseason | .0179 | .0222 | .0279 |
+| | previous_season | .0210 | .0246 | .0286 |
+| | league_average | .0254 | .0263 | .0321 |
+| **hr_rate** | marcel | **.0098** | **.0115** | **.0152** |
+| | marcel_preseason | .0098 | .0118 | .0155 |
+| | season_to_date | .0115 | .0123 | .0156 |
+| | bayes_preseason | .0099 | .0117 | .0153 |
+| | previous_season | .0121 | .0141 | .0167 |
+| | league_average | .0128 | .0135 | .0161 |
+| **iso** | marcel | **.0345** | **.0413** | .0567 |
+| | marcel_preseason | .0352 | .0428 | .0558 |
+| | season_to_date | .0410 | .0435 | .0594 |
+| | bayes_preseason | .0358 | .0436 | **.0551** |
+| | previous_season | .0418 | .0493 | .0584 |
+| | league_average | .0448 | .0472 | .0609 |
+| **babip** | marcel | **.0269** | .0350 | .0424 |
+| | marcel_preseason | .0270 | .0349 | **.0393** |
+| | season_to_date | .0286 | .0352 | .0461 |
+| | bayes_preseason | .0271 | **.0345** | .0417 |
+| | previous_season | .0344 | .0389 | .0411 |
+| | league_average | .0288 | .0352 | .0427 |
+
+Scored players (common across arms): K%/BB%/HR 315 · 231 · 126;
+ISO 308 · 213 · 80; BABIP 267 · 157 · **4**.
+
+Log loss orders the arms the same way wherever it applies; the spreads are
+tiny (K% at Jul 1: marcel .50704, marcel_preseason .50750, bayes .50784,
+league average .51587). Marcel-with-partial stays calibrated — decile gaps on
+K% at Jul 1 are within ±.018 and unsigned.
+
+## The in-season increment: `marcel` vs `marcel_preseason`
+
+Change in MAE from adding the partial season to Marcel (negative = better):
+
+| Component | May 1 | Jul 1 | Aug 1 |
+|---|---|---|---|
+| k_rate | **−5.1%** | **−4.6%** | **−6.1%** |
+| bb_rate | **−3.9%** | **−5.6%** | **−2.7%** |
+| hr_rate | −0.0% | **−2.3%** | **−2.3%** |
+| iso | **−2.0%** | **−3.5%** | +1.6% |
+| babip | −0.4% | +0.4% | +7.8% *(n=4)* |
+
+## Reading it
+
+**In-season data helps, it helps most where skill is most real, and it is
+worth more than our model is.** Folding the current season into Marcel cuts
+rest-of-season K% error by 4.6–6.1% and BB% error by 2.7–5.6% at every
+horizon; ISO gains 2.0–3.5% through July, HR/PA gains 2.3% from July onward
+and nothing in April; BABIP gains nothing at any cutoff, the same "BABIP is mostly
+luck" result the season-level table shows, now confirmed within a season. The
+ordering of the increment — K% > BB% > ISO ≈ HR > BABIP — is the reliability
+ordering, as it should be: in-season PA only carry information about the
+components that carry information at all. Two things follow. First, **the
+increment is not small in context**: 5% of K% MAE is about half the entire
+preseason spread between Marcel and Depth Charts, the best public system
+([accuracy-2026.md](accuracy-2026.md)), and we get it for free by not
+throwing away April. Second, **it is bigger than our model's edge**:
+`marcel` beats `bayes_preseason` on K% by 6% at May 1 and 11% at Aug 1, and
+`bayes_preseason` never beats `marcel_preseason` on K% either (a tie at May 1,
+5% behind at Jul 1 and Aug 1) — so the Bayesian components buy nothing over
+Marcel on the same information, while the *same* information advantage that
+in-season data provides is larger than the entire gap between them. The route to a
+better rest-of-season number runs through *ingesting the current season*, not
+through a fancier prior. It also matters **how** you ingest it:
+`season_to_date` — this year's rate regressed with the right ballast — loses
+to Marcel-with-partial at every cutoff and every component, though its
+disadvantage on K% shrinks from +21% at May 1 to +1.5% at Aug 1 as the sample
+stabilizes. The value is in *adding* the partial season to the multi-year
+prior, not in replacing it.
+
+## Caveats
+
+- **MAE rises across cutoffs for every arm.** That is the realized window
+  shrinking (a shorter rest-of-season is a noisier target), not the models
+  degrading. Only the within-cutoff comparison between arms is meaningful.
+- **BABIP at Aug 1 is 4 players.** `min_trials=100` on BIP is brutal at a
+  one-month horizon; treat that column as absent, and the Jul 1 BABIP column
+  (n=157) as thin.
+- **The 2026 season here ends Sept 1**, the last date in the PA parquet, so
+  "rest of season" at the Aug 1 cutoff is one month, not two.
+- **`bayes_preseason` is a fixed file, not a refit.** It is our Apr 10
+  projection for 2026 (`projection_year == 2026`), scored unchanged at all
+  three cutoffs — deliberately, since it is the no-in-season-information arm.
+  It is *not* an answer to "how good would our model be if refit on July 1";
+  that is what this harness exists to judge once the Modal refits land.
+- **PA-derived seasons are not identical to the Stats API totals.** The
+  Statcast universe runs ~0.7% more PA per player (mean +1.8 PA over 2026;
+  AB, K, BB, HR all within a few counts). Training mixes the two — prior
+  seasons from the API table, the partial current season from PA data — so a
+  hair of the in-season increment could be universe drift rather than signal.
+  Rebuilding prior seasons from `pa_outcomes_<year>.parquet` would close it;
+  only 2026 exists in R2 today.
+- Components are derived from the PA outcome flags with the standard
+  identities (AB = PA − BB − HBP − SF − SH − interference; BIP = AB − K − HR
+  + SF; xb_points = 2B + 2·3B + 3·HR). All five components are fully
+  derivable; nothing was dropped.

--- a/scripts/run_intraseason_backtest.py
+++ b/scripts/run_intraseason_backtest.py
@@ -1,0 +1,159 @@
+"""Intra-season walk-forward: cut the season at a date, project the rest.
+
+Answers the question the product actually asks — *given everything through
+2026-07-01, how good are the rest-of-season rate projections?* — with the
+same scoring path as the season-level harness (`src/eval/backtest.py`).
+
+Arms at every cutoff:
+
+    marcel            5/4/3 with the partial current season as the most
+                      recent year (Marcel weights by PA, so it scales itself)
+    marcel_preseason  the same Marcel with the partial season withheld — the
+                      control that isolates the value of in-season data
+    season_to_date    this year's rate regressed to league with the
+                      component's stabilization-point ballast
+    previous_season   the last complete season, unregressed
+    league_average    league rate through the cutoff
+    bayes_preseason   our Bayesian components, fit through 2025 (a fixed
+                      preseason file, so also a no-in-season-info arm)
+
+Usage:
+    python scripts/run_intraseason_backtest.py
+    python scripts/run_intraseason_backtest.py --cutoffs 2026-07-01 --components k_rate
+    python scripts/run_intraseason_backtest.py --markdown            # doc table
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pandas as pd
+
+from src.data.pa_outcomes import load_pa_outcomes
+from src.eval import backtest, calibration, score
+from src.eval.backtest import frame_provider
+from src.eval.baselines import INTRASEASON_BASELINES
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_COMPONENTS = ["k_rate", "bb_rate", "hr_rate", "babip", "iso"]
+DEFAULT_CUTOFFS = ["2026-05-01", "2026-07-01", "2026-08-01"]
+ARM_ORDER = ["marcel", "season_to_date", "marcel_preseason",
+             "bayes_preseason", "previous_season", "league_average"]
+
+
+def bayes_provider(component: str, projections_dir: Path):
+    """Our preseason Bayesian projection for one component, or None if absent.
+
+    These files were fit through 2025 and carry a `projection_year` column;
+    `frame_provider` picks the predict year's row, so the same file is the
+    no-in-season-information arm at every cutoff.
+    """
+    path = projections_dir / f"{component}_projections_2026.parquet"
+    if not path.exists():
+        return None
+    df = pd.read_parquet(path)
+    return frame_provider(df, pred_col=f"projected_{component}")
+
+
+def run(
+    components: list[str],
+    cutoffs: list[str],
+    seasons: pd.DataFrame,
+    pa: pd.DataFrame,
+    projections_dir: Path,
+    min_trials: int,
+    predict_year: int,
+) -> pd.DataFrame:
+    tables = []
+    for component in components:
+        providers = dict(INTRASEASON_BASELINES)
+        bayes = bayes_provider(component, projections_dir)
+        if bayes is not None:
+            providers["bayes_preseason"] = bayes
+        for cutoff in cutoffs:
+            results = backtest(
+                component, cutoff_date=cutoff, predict_year=predict_year,
+                seasons=seasons, pa_frame=pa, providers=providers,
+                min_trials=min_trials,
+            )
+            tables.append(score(results).assign(cutoff=cutoff))
+    return pd.concat(tables, ignore_index=True)
+
+
+def to_markdown(scores: pd.DataFrame, components: list[str]) -> str:
+    """One block per component: rows are arms, columns are cutoffs (MAE)."""
+    lines = ["| Component | Arm | " + " | ".join(
+        f"MAE {c[5:]}" for c in sorted(scores["cutoff"].unique())) + " |"]
+    lines.append("|---|---|" + "---|" * scores["cutoff"].nunique())
+    for component in components:
+        g = scores[scores["component"] == component]
+        if g.empty:
+            continue
+        wide = g.pivot(index="model", columns="cutoff", values="mae")
+        order = [m for m in ARM_ORDER if m in wide.index]
+        first = True
+        for model in order:
+            label = f"**{component}**" if first else ""
+            first = False
+            cells = []
+            for cutoff in sorted(wide.columns):
+                v = wide.loc[model, cutoff]
+                best = v == wide[cutoff].min()
+                cells.append(f"**{v:.4f}**" if best else f"{v:.4f}")
+            lines.append(f"| {label} | {model} | " + " | ".join(cells) + " |")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--components", nargs="+", default=DEFAULT_COMPONENTS)
+    parser.add_argument("--cutoffs", nargs="+", default=DEFAULT_CUTOFFS)
+    parser.add_argument("--predict-year", type=int, default=2026)
+    parser.add_argument("--min-trials", type=int, default=100)
+    parser.add_argument("--seasons", type=Path,
+                        default=ROOT / "data/parquet/hitter_seasons_api.parquet")
+    parser.add_argument("--pa-dir", type=Path, default=ROOT / "data/parquet",
+                        help="cache dir for pa_outcomes_<year>.parquet (pulled from R2)")
+    parser.add_argument("--projections-dir", type=Path,
+                        default=ROOT / "data/projections")
+    parser.add_argument("--markdown", action="store_true",
+                        help="print the docs table instead of the wide scores")
+    parser.add_argument("--calibration-model", default=None)
+    parser.add_argument("--csv-out", type=Path, default=None)
+    args = parser.parse_args()
+
+    seasons = pd.read_parquet(args.seasons)
+    pa = load_pa_outcomes(args.predict_year, data_dir=args.pa_dir)
+
+    scores = run(args.components, args.cutoffs, seasons, pa,
+                 args.projections_dir, args.min_trials, args.predict_year)
+
+    if args.markdown:
+        print(to_markdown(scores, args.components))
+    else:
+        for cutoff in args.cutoffs:
+            print(f"\n=== cutoff {cutoff} → rest of {args.predict_year} ===")
+            g = scores[scores["cutoff"] == cutoff]
+            print(g.drop(columns="cutoff").round(5).to_string(index=False))
+
+    if args.calibration_model:
+        results = backtest(
+            args.components[0], cutoff_date=args.cutoffs[-1],
+            predict_year=args.predict_year, seasons=seasons, pa_frame=pa,
+            min_trials=args.min_trials,
+        )
+        print(f"\nCalibration ({args.calibration_model}, {args.components[0]}, "
+              f"{args.cutoffs[-1]}):")
+        print(calibration(results, args.calibration_model).round(4).to_string(index=False))
+
+    if args.csv_out:
+        args.csv_out.parent.mkdir(parents=True, exist_ok=True)
+        scores.to_csv(args.csv_out, index=False)
+        print(f"\nwrote {args.csv_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/pa_outcomes.py
+++ b/src/data/pa_outcomes.py
@@ -1,0 +1,90 @@
+"""Loader for the PA-level outcome parquets (`pa_outcomes/pa_outcomes_<year>.parquet` in R2).
+
+One row per plate appearance, written by `src/data/pa_outcomes_pipeline.py`.
+The intra-season backtest (`src/eval/intraseason.py`) needs these because the
+season-level table has no dates: you cannot ask "what did we know on July 1"
+of a frame whose finest grain is a season.
+
+Files land in `data/parquet/` (gitignored) and are cached there — the first
+call downloads, later calls read the local copy.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+PA_OUTCOMES_PREFIX = "pa_outcomes/"
+LOCAL_DIR = Path("data/parquet")
+
+# Columns the intra-season aggregation actually needs. Reading only these
+# keeps a 157k-row season under a few MB in memory.
+REQUIRED_COLUMNS = [
+    "batter", "game_pk", "game_date", "game_year", "event",
+    "is_k", "is_bb", "is_hbp", "is_hit", "is_hr", "is_single",
+    "is_double", "is_triple",
+]
+
+
+def r2_key(year: int) -> str:
+    return f"{PA_OUTCOMES_PREFIX}pa_outcomes_{year}.parquet"
+
+
+def local_path(year: int, data_dir: str | Path = LOCAL_DIR) -> Path:
+    return Path(data_dir) / f"pa_outcomes_{year}.parquet"
+
+
+def available_years(prefix: str = PA_OUTCOMES_PREFIX) -> list[int]:
+    """Years with a PA-outcomes parquet in R2. Empty list if R2 is unreachable."""
+    from src.data.r2 import bucket, get_s3_client
+
+    client = get_s3_client()
+    years: list[int] = []
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket(), Prefix=prefix):
+        for obj in page.get("Contents", []):
+            stem = Path(obj["Key"]).stem
+            tail = stem.rsplit("_", 1)[-1]
+            if tail.isdigit():
+                years.append(int(tail))
+    return sorted(set(years))
+
+
+def download(year: int, data_dir: str | Path = LOCAL_DIR, refresh: bool = False) -> Path:
+    """Fetch one year's PA parquet from R2 into `data_dir`; returns the path."""
+    from src.data.r2 import bucket, get_s3_client
+
+    path = local_path(year, data_dir)
+    if path.exists() and not refresh:
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("downloading %s -> %s", r2_key(year), path)
+    get_s3_client().download_file(bucket(), r2_key(year), str(path))
+    return path
+
+
+def load_pa_outcomes(
+    year: int,
+    data_dir: str | Path = LOCAL_DIR,
+    columns: list[str] | None = REQUIRED_COLUMNS,
+    allow_download: bool = True,
+) -> pd.DataFrame:
+    """PA-level outcomes for one season, cached locally.
+
+    `game_date` comes back as a pandas datetime so cutoffs can be compared
+    without string-format assumptions.
+    """
+    path = local_path(year, data_dir)
+    if not path.exists():
+        if not allow_download:
+            raise FileNotFoundError(
+                f"{path} not found and allow_download=False — run "
+                f"`python -c \"from src.data.pa_outcomes import download; download({year})\"`"
+            )
+        download(year, data_dir)
+    df = pd.read_parquet(path, columns=columns)
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    return df

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -1,11 +1,19 @@
 """Backtest harness (roadmap 0.2).
 
 The factory's objective function: every model change is judged by
-`backtest()` numbers against dumb baselines, never by eyeball.
+`backtest()` numbers against dumb baselines, never by eyeball. With a
+`cutoff_date` the same call answers the rest-of-season question — given
+everything through July 1, how good is the rest of the year?
 """
 from src.eval.backtest import (
     backtest, score, calibration, COMPONENTS, parquet_provider, frame_provider,
 )
+from src.eval.intraseason import (
+    aggregate_pa, assert_split_clean, backtest_intraseason,
+    partial_and_realized, split_at_cutoff,
+)
 
 __all__ = ["backtest", "score", "calibration", "COMPONENTS",
-           "parquet_provider", "frame_provider"]
+           "parquet_provider", "frame_provider",
+           "backtest_intraseason", "aggregate_pa", "partial_and_realized",
+           "split_at_cutoff", "assert_split_clean"]

--- a/src/eval/backtest.py
+++ b/src/eval/backtest.py
@@ -4,6 +4,13 @@ Interface (roadmap 0.2):
 
     backtest(component, train_through_year, predict_year) -> DataFrame
 
+and, for rest-of-season projections, the same call with a date cutoff:
+
+    backtest(component, cutoff_date="2026-07-01", pa_frame=..., seasons=...)
+
+which trains on everything through July 1 and scores the rest of the season
+(`src/eval/intraseason.py`).
+
 The harness slices a season-level frame at the training cutoff, hands ONLY
 past seasons to each prediction provider, joins realized outcomes from the
 predict year, and scores component-wise log loss, MAE, RMSE, and calibration
@@ -49,22 +56,27 @@ Provider = Callable[[pd.DataFrame, ComponentSpec, int], pd.DataFrame]
 
 def backtest(
     component: str,
-    train_through_year: int,
+    train_through_year: int | None = None,
     predict_year: int | None = None,
     *,
     seasons: pd.DataFrame,
     providers: dict[str, Provider] | None = None,
     min_trials: int = 100,
     common_players: bool = True,
+    cutoff_date: str | None = None,
+    pa_frame: pd.DataFrame | None = None,
 ) -> pd.DataFrame:
     """Run one train/predict split for one component.
 
     Args:
         component: key in COMPONENTS.
         train_through_year: last season providers are allowed to see.
-        predict_year: season to score against (default: the next one).
+            Not used (and not required) when `cutoff_date` is given.
+        predict_year: season to score against (default: the next one, or the
+            cutoff's own year in intra-season mode).
         seasons: season-level frame (see module docstring).
-        providers: model name → provider. Defaults to the three baselines.
+        providers: model name → provider. Defaults to the three baselines
+            (plus `season_to_date` in intra-season mode).
             Add your model with e.g. {"bayes": parquet_provider(path), **BASELINES}.
         min_trials: drop realized seasons below this many trials — tiny
             samples measure noise, not skill.
@@ -72,16 +84,35 @@ def backtest(
             intersection of their coverage). Without this a model that
             covers rookies is scored on a harder population than one that
             doesn't, and the comparison is meaningless.
+        cutoff_date: ISO date. Switches the harness to intra-season mode:
+            training is the prior seasons plus the current season *through*
+            the cutoff, and the realized side is the rest of that season.
+            Requires `pa_frame` (PA-level outcomes for the predict year) —
+            season totals have no dates to cut on. See
+            `src/eval/intraseason.py`.
+        pa_frame: PA-level outcomes, only used with `cutoff_date`.
 
     Returns:
         Long frame: [component, model, batter, predicted, realized_successes,
         realized_rate, trials]. Feed to score() / calibration().
     """
+    if cutoff_date is not None:
+        from src.eval.intraseason import backtest_intraseason
+
+        return backtest_intraseason(
+            component, cutoff_date, predict_year, seasons=seasons,
+            pa_frame=pa_frame, providers=providers, min_trials=min_trials,
+            common_players=common_players,
+        )
+    if pa_frame is not None:
+        raise ValueError("pa_frame is only meaningful with cutoff_date")
+    if train_through_year is None:
+        raise ValueError("train_through_year is required without a cutoff_date")
+
     spec = COMPONENTS[component]
     predict_year = predict_year or train_through_year + 1
     if predict_year <= train_through_year:
         raise ValueError("predict_year must be after train_through_year")
-    providers = providers or dict(BASELINES)
 
     # The leakage guard: providers never see the predict year.
     train = seasons[seasons["season"] <= train_through_year].copy()
@@ -89,9 +120,34 @@ def backtest(
         raise ValueError(f"no training seasons at or before {train_through_year}")
 
     realized = seasons[seasons["season"] == predict_year].copy()
+    return _run_split(
+        component, spec, train, realized, predict_year,
+        providers=providers, min_trials=min_trials,
+        common_players=common_players,
+    )
+
+
+def _run_split(
+    component: str,
+    spec: ComponentSpec,
+    train: pd.DataFrame,
+    realized: pd.DataFrame,
+    predict_year: int,
+    *,
+    providers: dict[str, Provider] | None,
+    min_trials: int,
+    common_players: bool,
+) -> pd.DataFrame:
+    """Score providers trained on `train` against `realized`.
+
+    The shared tail of every split — season-level or intra-season. `train`
+    and `realized` are already sliced; nothing here re-checks the cutoff,
+    that is the caller's leakage guard.
+    """
+    providers = providers or dict(BASELINES)
     realized = realized[realized[spec.trials] >= min_trials]
     if realized.empty:
-        raise ValueError(f"no realized seasons with >= {min_trials} "
+        raise ValueError(f"no realized rows with >= {min_trials} "
                          f"{spec.trials} in {predict_year}")
     realized = realized.assign(
         realized_rate=realized[spec.successes] / realized[spec.trials]

--- a/src/eval/baselines.py
+++ b/src/eval/baselines.py
@@ -6,6 +6,20 @@ cutoff — the harness enforces that, so a provider cannot leak the future.
 
 Baselines are deliberately dumb. They exist to be beaten; a model change
 that does not beat Marcel is a regression no matter how principled it looks.
+
+**Partial seasons.** In intra-season mode the training frame's most recent
+row is the current season *through the cutoff*, flagged `partial=True`. The
+baselines read that flag rather than assuming every season is complete:
+
+    marcel           treats it as the most recent season; because Marcel
+                     weights by trials, a 200-PA partial season naturally
+                     counts a third of a full one.
+    league_average   league rate through the cutoff (the latest season).
+    previous_season  the last *full* season — the partial one is skipped, so
+                     this stays the "no in-season information" arm.
+    season_to_date   the player's own partial-season rate regressed to
+                     league with the component's ballast: "just use this
+                     year".
 """
 from __future__ import annotations
 
@@ -18,6 +32,18 @@ from src.models.marcel import age_adjustment
 MARCEL_YEAR_WEIGHTS = {0: 5.0, 1: 4.0, 2: 3.0}  # years before predict_year - 1
 MARCEL_BALLAST = 200.0
 
+# Trials of league-average ballast for the season-to-date baseline: the
+# published stabilization points, where a player's own sample and the league
+# prior carry equal weight (Carleton / FanGraphs). BABIP's is huge, which is
+# the whole reason "he's hitting .400 on balls in play" means so little.
+SEASON_TO_DATE_BALLAST = {
+    "k_rate": 60.0,     # PA
+    "bb_rate": 120.0,   # PA
+    "hr_rate": 170.0,   # PA
+    "babip": 820.0,     # BIP
+    "iso": 160.0,       # AB
+}
+
 
 def _league_rate(train: pd.DataFrame, spec, year: int | None = None) -> float:
     """Trials-weighted league rate, optionally for a single season."""
@@ -25,20 +51,64 @@ def _league_rate(train: pd.DataFrame, spec, year: int | None = None) -> float:
     return float(df[spec.successes].sum() / df[spec.trials].sum())
 
 
+def _partial_mask(train: pd.DataFrame) -> pd.Series:
+    """Boolean mask of partial (through-the-cutoff) rows; all False without the flag."""
+    if "partial" not in train.columns:
+        return pd.Series(False, index=train.index)
+    return train["partial"].fillna(False).astype(bool)
+
+
+def full_seasons(train: pd.DataFrame) -> pd.DataFrame:
+    """Training rows for complete seasons only (drops a partial current season)."""
+    return train[~_partial_mask(train)]
+
+
+def latest_rows(train: pd.DataFrame) -> pd.DataFrame:
+    """The most recent training slice: the partial season if there is one,
+    else the last full season."""
+    partial = train[_partial_mask(train)]
+    if not partial.empty:
+        return partial
+    return train[train["season"] == int(train["season"].max())]
+
+
 def league_average(train: pd.DataFrame, spec, predict_year: int) -> pd.DataFrame:
-    """Everyone projects to the most recent training season's league rate."""
-    last = int(train["season"].max())
-    rate = _league_rate(train, spec, last)
-    batters = train.loc[train["season"] == last, "batter"].unique()
-    return pd.DataFrame({"batter": batters, "predicted": rate})
+    """Everyone projects to the most recent training slice's league rate.
+
+    With a partial current season that is the league rate through the cutoff.
+    """
+    g = latest_rows(train)
+    rate = float(g[spec.successes].sum() / g[spec.trials].sum())
+    return pd.DataFrame({"batter": g["batter"].unique(), "predicted": rate})
 
 
 def previous_season(train: pd.DataFrame, spec, predict_year: int) -> pd.DataFrame:
-    """Player's own rate in the last training season, no regression."""
-    last = int(train["season"].max())
-    g = train[train["season"] == last]
+    """Player's own rate in the last *complete* training season, no regression."""
+    full = full_seasons(train)
+    if full.empty:
+        raise ValueError("previous_season needs at least one complete season")
+    last = int(full["season"].max())
+    g = full[full["season"] == last]
     pred = g[spec.successes] / g[spec.trials]
     return pd.DataFrame({"batter": g["batter"].values, "predicted": pred.values})
+
+
+def season_to_date(train: pd.DataFrame, spec, predict_year: int) -> pd.DataFrame:
+    """The player's own rate so far this season, regressed to league.
+
+    pred = (successes + b·league) / (trials + b), with b the component's
+    stabilization point. A player with zero trials gets exactly the league
+    rate, which is what makes this a well-behaved arm at an April cutoff.
+    """
+    g = latest_rows(train).groupby("batter", as_index=False).agg(
+        successes=(spec.successes, "sum"), trials=(spec.trials, "sum")
+    )
+    league = float(g["successes"].sum() / g["trials"].sum())
+    b = SEASON_TO_DATE_BALLAST.get(spec.name, MARCEL_BALLAST)
+    return pd.DataFrame({
+        "batter": g["batter"].values,
+        "predicted": (g["successes"] + b * league) / (g["trials"] + b),
+    })
 
 
 def marcel(train: pd.DataFrame, spec, predict_year: int) -> pd.DataFrame:
@@ -80,8 +150,28 @@ def marcel(train: pd.DataFrame, spec, predict_year: int) -> pd.DataFrame:
     return out
 
 
+def marcel_preseason(train: pd.DataFrame, spec, predict_year: int) -> pd.DataFrame:
+    """Marcel with the partial current season withheld.
+
+    The control arm for intra-season backtests: identical to the Marcel a
+    preseason run would have produced, scored on the same rest-of-season
+    outcomes. `marcel` minus `marcel_preseason` is the value of in-season
+    information, with the model held fixed.
+    """
+    return marcel(full_seasons(train), spec, predict_year)
+
+
 BASELINES = {
     "marcel": marcel,
     "previous_season": previous_season,
     "league_average": league_average,
+}
+
+# `season_to_date` and `marcel_preseason` only say something interesting when
+# the training frame carries a partial current season, so they are opt-in at
+# the season level and default in intra-season mode.
+INTRASEASON_BASELINES = {
+    **BASELINES,
+    "season_to_date": season_to_date,
+    "marcel_preseason": marcel_preseason,
 }

--- a/src/eval/intraseason.py
+++ b/src/eval/intraseason.py
@@ -191,14 +191,16 @@ def build_training_frame(
     prior = seasons[seasons["season"] < predict_year].copy()
     prior["partial"] = False
     if "age" in prior.columns and "age" not in partial.columns:
-        # Carry the predict-year age through when the season table has it,
-        # else age forward from the most recent prior season.
-        ages = seasons[seasons["season"] == predict_year].set_index("batter")["age"] \
-            if "age" in seasons.columns and (seasons["season"] == predict_year).any() \
-            else None
+        # Marcel's age adjustment reads `age` off the most recent training
+        # slice, which is now the partial season. Take the predict year's age
+        # from the season table when it has one; otherwise age the player
+        # forward from his last prior season. Missing ages stay NaN — the
+        # adjustment already falls back to 1.0 for those.
+        current = seasons[seasons["season"] == predict_year]
         partial = partial.copy()
-        if ages is not None:
-            partial["age"] = partial["batter"].map(ages)
+        if "age" in seasons.columns and not current.empty:
+            partial["age"] = partial["batter"].map(
+                current.set_index("batter")["age"])
         else:
             last_prior = (prior.sort_values("season").groupby("batter")
                           .agg(age=("age", "last"), season=("season", "last")))

--- a/src/eval/intraseason.py
+++ b/src/eval/intraseason.py
@@ -1,0 +1,267 @@
+"""Intra-season walk-forward: cut the season at a date, project the rest.
+
+The season-level harness (`src/eval/backtest.py`) answers "given everything
+through 2025, how good is 2026?". The product is a *rest-of-season*
+projection, so the question that matters is "given everything through
+2026-07-01, how good is the rest of 2026?" — and answering it needs dates,
+which the season table does not have. This module supplies them from the
+PA-level outcome parquets and reuses the harness's scoring path unchanged.
+
+The split at a cutoff date produces two season-shaped frames:
+
+    partial   PA with game_date <  cutoff, aggregated to the season schema
+              and marked `partial=True` — appended to the prior full seasons
+              to make the training frame.
+    realized  PA with game_date >= cutoff, aggregated the same way — the
+              rest-of-season outcome every provider is scored against.
+
+`assert_split_clean` is the leakage guard: no realized PA before the cutoff,
+no training PA on or after it.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from src.eval.backtest import COMPONENTS, ComponentSpec, Provider, _run_split
+from src.eval.baselines import INTRASEASON_BASELINES
+
+# Events that are plate appearances but not at-bats. AB = PA − BB − HBP −
+# SF − SH − reached-on-interference (the same identity the Stats API uses,
+# so PA-derived seasons line up with `hitter_seasons_api.parquet`).
+SAC_FLY_EVENTS = {"sac_fly", "sac_fly_double_play"}
+SAC_BUNT_EVENTS = {"sac_bunt", "sac_bunt_double_play"}
+INTERFERENCE_EVENTS = {"catcher_interf"}
+
+# Season-schema columns produced by aggregate_pa (the harness reads a subset).
+COUNT_COLUMNS = [
+    "pa", "ab", "h", "doubles", "triples", "hr", "k", "bb", "hbp", "sf",
+    "sh", "ci", "xb_points", "bip", "hits_in_play", "games",
+]
+
+
+def aggregate_pa(pa: pd.DataFrame, season: int | None = None) -> pd.DataFrame:
+    """Roll PA-level outcomes up to the season-table schema, one row per batter.
+
+    Produces the columns `build_seasons_table` produces (pa, ab, h, doubles,
+    triples, hr, k, bb, hbp, sf, xb_points, bip, hits_in_play) plus `games`
+    and the `first_game_date` / `last_game_date` bounds the leakage guard
+    checks. `season` defaults to the frame's `game_year`.
+
+    Counts are forced to int64: the outcome flags are int8 on disk and
+    `2*triples + 3*hr` silently overflows if they are left that way.
+    """
+    if pa.empty:
+        # Typed, not just named: an object-dtype empty frame poisons the
+        # concat in build_training_frame and turns `batter` into objects.
+        empty = {c: pd.Series(dtype="int64")
+                 for c in ["batter", "season", *COUNT_COLUMNS]}
+        empty["first_game_date"] = pd.Series(dtype="datetime64[ns]")
+        empty["last_game_date"] = pd.Series(dtype="datetime64[ns]")
+        return pd.DataFrame(empty)
+
+    df = pa.copy()
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    event = df["event"]
+    flags = {
+        "_k": df["is_k"], "_bb": df["is_bb"], "_hbp": df["is_hbp"],
+        "_h": df["is_hit"], "_hr": df["is_hr"],
+        "_2b": df["is_double"], "_3b": df["is_triple"],
+        "_sf": event.isin(SAC_FLY_EVENTS),
+        "_sh": event.isin(SAC_BUNT_EVENTS),
+        "_ci": event.isin(INTERFERENCE_EVENTS),
+    }
+    for name, col in flags.items():
+        df[name] = col.astype("int64")
+
+    g = df.groupby("batter", as_index=False).agg(
+        pa=("_k", "size"),
+        k=("_k", "sum"),
+        bb=("_bb", "sum"),
+        hbp=("_hbp", "sum"),
+        h=("_h", "sum"),
+        hr=("_hr", "sum"),
+        doubles=("_2b", "sum"),
+        triples=("_3b", "sum"),
+        sf=("_sf", "sum"),
+        sh=("_sh", "sum"),
+        ci=("_ci", "sum"),
+        games=("game_pk", "nunique"),
+        first_game_date=("game_date", "min"),
+        last_game_date=("game_date", "max"),
+    )
+    for c in ["pa", "k", "bb", "hbp", "h", "hr", "doubles", "triples",
+              "sf", "sh", "ci", "games"]:
+        g[c] = g[c].astype("int64")
+
+    g["ab"] = g["pa"] - g["bb"] - g["hbp"] - g["sf"] - g["sh"] - g["ci"]
+    g["xb_points"] = g["doubles"] + 2 * g["triples"] + 3 * g["hr"]
+    g["bip"] = g["ab"] - g["k"] - g["hr"] + g["sf"]
+    g["hits_in_play"] = g["h"] - g["hr"]
+
+    if season is None:
+        season = int(df["game_year"].iloc[0]) if "game_year" in df else int(
+            df["game_date"].dt.year.iloc[0])
+    g.insert(1, "season", season)
+    return g[["batter", "season", *COUNT_COLUMNS,
+              "first_game_date", "last_game_date"]]
+
+
+def split_at_cutoff(
+    pa: pd.DataFrame, cutoff_date: str | pd.Timestamp
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """(PA strictly before the cutoff, PA on or after it)."""
+    cutoff = pd.Timestamp(cutoff_date)
+    dates = pd.to_datetime(pa["game_date"])
+    return pa[dates < cutoff].copy(), pa[dates >= cutoff].copy()
+
+
+def partial_and_realized(
+    pa: pd.DataFrame,
+    cutoff_date: str | pd.Timestamp,
+    season: int | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Season-shaped (partial, realized) frames either side of the cutoff.
+
+    `partial` carries `partial=True`; `realized` carries `partial=False`.
+    """
+    before, after = split_at_cutoff(pa, cutoff_date)
+    partial = aggregate_pa(before, season).assign(partial=True)
+    realized = aggregate_pa(after, season).assign(partial=False)
+    return partial, realized
+
+
+def assert_split_clean(
+    train: pd.DataFrame,
+    realized: pd.DataFrame,
+    cutoff_date: str | pd.Timestamp,
+    predict_year: int,
+) -> None:
+    """Leakage guard for a dated split.
+
+    Raises ValueError if any training row saw a game on or after the cutoff,
+    if any realized row contains a game before it, if training carries a
+    season after the predict year, or if realized is not the predict year.
+    Rows without date bounds (prior full seasons out of the season table)
+    are checked on `season` alone.
+    """
+    cutoff = pd.Timestamp(cutoff_date)
+
+    if not train.empty and int(train["season"].max()) > predict_year:
+        raise ValueError(
+            f"leakage: training frame contains season "
+            f"{int(train['season'].max())} > predict year {predict_year}"
+        )
+    if "last_game_date" in train.columns:
+        late = train["last_game_date"].dropna()
+        bad = late[late >= cutoff]
+        if len(bad):
+            raise ValueError(
+                f"leakage: {len(bad)} training row(s) contain PA on or after "
+                f"the cutoff {cutoff.date()} (latest {bad.max().date()})"
+            )
+    if realized.empty:
+        raise ValueError("leakage guard: realized frame is empty")
+    if set(realized["season"].unique()) != {predict_year}:
+        raise ValueError(
+            f"realized frame must be entirely season {predict_year}, got "
+            f"{sorted(realized['season'].unique())}"
+        )
+    if "first_game_date" in realized.columns:
+        early = realized["first_game_date"].dropna()
+        bad = early[early < cutoff]
+        if len(bad):
+            raise ValueError(
+                f"leakage: {len(bad)} realized row(s) contain PA before the "
+                f"cutoff {cutoff.date()} (earliest {bad.min().date()})"
+            )
+
+
+def build_training_frame(
+    seasons: pd.DataFrame,
+    partial: pd.DataFrame,
+    predict_year: int,
+) -> pd.DataFrame:
+    """Prior full seasons + the partial current season, in one frame.
+
+    Prior seasons come from the season table (season < predict_year) and are
+    marked `partial=False`; any season-table rows for the predict year are
+    dropped — the partial aggregate replaces them, and keeping both would
+    hand providers the full current season.
+    """
+    prior = seasons[seasons["season"] < predict_year].copy()
+    prior["partial"] = False
+    if "age" in prior.columns and "age" not in partial.columns:
+        # Carry the predict-year age through when the season table has it,
+        # else age forward from the most recent prior season.
+        ages = seasons[seasons["season"] == predict_year].set_index("batter")["age"] \
+            if "age" in seasons.columns and (seasons["season"] == predict_year).any() \
+            else None
+        partial = partial.copy()
+        if ages is not None:
+            partial["age"] = partial["batter"].map(ages)
+        else:
+            last_prior = (prior.sort_values("season").groupby("batter")
+                          .agg(age=("age", "last"), season=("season", "last")))
+            partial["age"] = partial["batter"].map(
+                last_prior["age"] + (predict_year - last_prior["season"])
+            )
+    return pd.concat([prior, partial], ignore_index=True)
+
+
+def backtest_intraseason(
+    component: str,
+    cutoff_date: str | pd.Timestamp,
+    predict_year: int | None = None,
+    *,
+    seasons: pd.DataFrame,
+    pa_frame: pd.DataFrame | None = None,
+    partial: pd.DataFrame | None = None,
+    realized: pd.DataFrame | None = None,
+    providers: dict[str, Provider] | None = None,
+    min_trials: int = 100,
+    common_players: bool = True,
+) -> pd.DataFrame:
+    """One dated train/predict split: everything before `cutoff_date`, score
+    the rest of `predict_year`.
+
+    Args:
+        component: key in COMPONENTS.
+        cutoff_date: ISO date. Training sees PA strictly before it.
+        predict_year: season being cut (default: the cutoff's year).
+        seasons: season-level frame for the prior seasons (2019-2025 etc.).
+        pa_frame: PA-level outcomes for the predict year. Optional if
+            `partial` and `realized` are supplied pre-aggregated.
+        providers: model name → provider. Defaults to the baselines plus
+            `season_to_date`.
+        min_trials: minimum realized (rest-of-season) trials to be scored.
+        common_players: score every model on the same batters.
+
+    Returns:
+        The same long frame `backtest()` returns — feed it to score() /
+        calibration().
+    """
+    spec: ComponentSpec = COMPONENTS[component]
+    cutoff = pd.Timestamp(cutoff_date)
+    predict_year = predict_year or cutoff.year
+    providers = providers or dict(INTRASEASON_BASELINES)
+
+    if partial is None or realized is None:
+        if pa_frame is None:
+            raise ValueError("pass pa_frame, or both partial and realized")
+        pa_year = pa_frame
+        if "game_year" in pa_year.columns:
+            pa_year = pa_year[pa_year["game_year"] == predict_year]
+        if pa_year.empty:
+            raise ValueError(f"no PA rows for {predict_year} in pa_frame")
+        partial, realized = partial_and_realized(pa_year, cutoff, predict_year)
+
+    train = build_training_frame(seasons, partial, predict_year)
+    assert_split_clean(train, realized, cutoff, predict_year)
+    if train.empty:
+        raise ValueError(f"no training data before {cutoff.date()}")
+
+    return _run_split(
+        component, spec, train, realized, predict_year,
+        providers=providers, min_trials=min_trials,
+        common_players=common_players,
+    )

--- a/tests/test_eval/test_intraseason.py
+++ b/tests/test_eval/test_intraseason.py
@@ -1,0 +1,324 @@
+"""Tests for the intra-season (dated cutoff) harness on synthetic PA frames."""
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.eval import backtest, score
+from src.eval.backtest import COMPONENTS
+from src.eval.baselines import (
+    SEASON_TO_DATE_BALLAST, league_average, marcel, marcel_preseason,
+    previous_season, season_to_date,
+)
+from src.eval.intraseason import (
+    aggregate_pa, assert_split_clean, backtest_intraseason,
+    build_training_frame, partial_and_realized, split_at_cutoff,
+)
+
+# Flags the PA-outcomes parquet carries, keyed by event, so the synthetic
+# frames below match the real schema exactly.
+EVENT_FLAGS = {
+    "strikeout":     dict(is_k=1),
+    "walk":          dict(is_bb=1),
+    "hit_by_pitch":  dict(is_hbp=1),
+    "single":        dict(is_hit=1, is_single=1),
+    "double":        dict(is_hit=1, is_double=1),
+    "triple":        dict(is_hit=1, is_triple=1),
+    "home_run":      dict(is_hit=1, is_hr=1),
+    "field_out":     dict(),
+    "sac_fly":       dict(),
+    "sac_bunt":      dict(),
+    "catcher_interf": dict(),
+}
+FLAG_COLS = ["is_k", "is_bb", "is_hbp", "is_hit", "is_hr",
+             "is_single", "is_double", "is_triple"]
+
+
+def pa_rows(batter: int, date: str, events: dict[str, int], game_pk: int = 1):
+    """Expand {event: count} into PA-level rows for one batter on one date."""
+    rows = []
+    for event, n in events.items():
+        for _ in range(n):
+            row = {"batter": batter, "game_pk": game_pk, "game_date": date,
+                   "game_year": int(date[:4]), "event": event}
+            row.update({c: 0 for c in FLAG_COLS})
+            row.update(EVENT_FLAGS[event])
+            rows.append(row)
+    return rows
+
+
+class TestAggregation:
+    def test_matches_hand_counts(self):
+        """One batter, a hand-countable line."""
+        pa = pd.DataFrame(pa_rows(1, "2026-04-01", {
+            "strikeout": 3, "walk": 2, "hit_by_pitch": 1, "single": 4,
+            "double": 2, "triple": 1, "home_run": 2, "field_out": 8,
+            "sac_fly": 1, "sac_bunt": 1, "catcher_interf": 1,
+        }))
+        agg = aggregate_pa(pa).iloc[0]
+
+        assert agg["pa"] == 26           # every row is a plate appearance
+        assert agg["k"] == 3
+        assert agg["bb"] == 2
+        assert agg["hbp"] == 1
+        assert agg["h"] == 9             # 4 + 2 + 1 + 2
+        assert agg["hr"] == 2
+        assert agg["sf"] == 1 and agg["sh"] == 1 and agg["ci"] == 1
+        # AB = PA − BB − HBP − SF − SH − interference
+        assert agg["ab"] == 26 - 2 - 1 - 1 - 1 - 1 == 20
+        assert agg["xb_points"] == 2 + 2 * 1 + 3 * 2 == 10
+        assert agg["bip"] == 20 - 3 - 2 + 1 == 16
+        assert agg["hits_in_play"] == 9 - 2 == 7
+        assert agg["season"] == 2026
+        assert agg["games"] == 1
+
+    def test_counts_do_not_overflow_int8(self):
+        """The outcome flags are int8 on disk; 3*hr silently wraps if kept."""
+        pa = pd.DataFrame(pa_rows(1, "2026-04-01", {"home_run": 60}))
+        assert aggregate_pa(pa).iloc[0]["xb_points"] == 180
+
+    def test_multiple_batters_and_games(self):
+        rows = (pa_rows(1, "2026-04-01", {"strikeout": 2}, game_pk=1)
+                + pa_rows(1, "2026-04-02", {"single": 1}, game_pk=2)
+                + pa_rows(2, "2026-04-01", {"walk": 3}, game_pk=1))
+        agg = aggregate_pa(pd.DataFrame(rows)).set_index("batter")
+        assert agg.loc[1, "pa"] == 3 and agg.loc[1, "games"] == 2
+        assert agg.loc[2, "pa"] == 3 and agg.loc[2, "bb"] == 3
+        assert str(agg.loc[1, "first_game_date"].date()) == "2026-04-01"
+        assert str(agg.loc[1, "last_game_date"].date()) == "2026-04-02"
+
+    def test_empty_frame_returns_schema(self):
+        out = aggregate_pa(pd.DataFrame(columns=["batter"]))
+        assert out.empty and "hits_in_play" in out.columns
+
+
+class TestSplit:
+    def test_cutoff_day_belongs_to_the_realized_side(self):
+        pa = pd.DataFrame(
+            pa_rows(1, "2026-06-30", {"strikeout": 1})
+            + pa_rows(1, "2026-07-01", {"strikeout": 1})
+            + pa_rows(1, "2026-07-02", {"strikeout": 1})
+        )
+        before, after = split_at_cutoff(pa, "2026-07-01")
+        assert len(before) == 1 and len(after) == 2
+
+    def test_partial_and_realized_flags(self):
+        pa = pd.DataFrame(pa_rows(1, "2026-06-01", {"strikeout": 5})
+                          + pa_rows(1, "2026-08-01", {"walk": 5}))
+        partial, realized = partial_and_realized(pa, "2026-07-01", 2026)
+        assert bool(partial.iloc[0]["partial"]) is True
+        assert bool(realized.iloc[0]["partial"]) is False
+        assert partial.iloc[0]["k"] == 5 and realized.iloc[0]["bb"] == 5
+
+
+class TestLeakageGuard:
+    @pytest.fixture
+    def clean(self):
+        pa = pd.DataFrame(pa_rows(1, "2026-06-01", {"strikeout": 5})
+                          + pa_rows(1, "2026-08-01", {"strikeout": 5}))
+        return partial_and_realized(pa, "2026-07-01", 2026)
+
+    def test_clean_split_passes(self, clean):
+        partial, realized = clean
+        assert_split_clean(partial, realized, "2026-07-01", 2026)
+
+    def test_realized_row_before_cutoff_raises(self, clean):
+        partial, realized = clean
+        realized.loc[0, "first_game_date"] = pd.Timestamp("2026-06-15")
+        with pytest.raises(ValueError, match="realized row"):
+            assert_split_clean(partial, realized, "2026-07-01", 2026)
+
+    def test_training_row_after_cutoff_raises(self, clean):
+        partial, realized = clean
+        partial.loc[0, "last_game_date"] = pd.Timestamp("2026-07-15")
+        with pytest.raises(ValueError, match="training row"):
+            assert_split_clean(partial, realized, "2026-07-01", 2026)
+
+    def test_training_season_after_predict_year_raises(self, clean):
+        partial, realized = clean
+        partial.loc[0, "season"] = 2027
+        partial.loc[0, "last_game_date"] = pd.Timestamp("2027-04-01")
+        with pytest.raises(ValueError, match="> predict year"):
+            assert_split_clean(partial, realized, "2026-07-01", 2026)
+
+    def test_realized_wrong_season_raises(self, clean):
+        partial, realized = clean
+        realized.loc[0, "season"] = 2025
+        with pytest.raises(ValueError, match="must be entirely season"):
+            assert_split_clean(partial, realized, "2026-07-01", 2026)
+
+    def test_build_training_frame_drops_full_predict_year(self):
+        seasons = pd.DataFrame([
+            {"batter": 1, "season": 2025, "pa": 600, "k": 120, "age": 27},
+            {"batter": 1, "season": 2026, "pa": 600, "k": 200, "age": 28},
+        ])
+        partial = pd.DataFrame([{"batter": 1, "season": 2026, "pa": 200,
+                                 "k": 40, "partial": True}])
+        train = build_training_frame(seasons, partial, 2026)
+        # The season table's own 2026 row (the full year) must not survive.
+        assert len(train) == 2
+        assert train[train.season == 2026]["k"].tolist() == [40]
+        assert train[train.season == 2026]["age"].tolist() == [28]
+
+
+def _train_frame(partial_pa: int, partial_k_rate: float = 0.50) -> pd.DataFrame:
+    """Two full seasons at .20 K% plus a partial 2026 at `partial_k_rate`.
+
+    A second batter holds the league rate at .20 so regression targets are
+    stable across the partial sizes being compared.
+    """
+    rows = []
+    for season in (2024, 2025):
+        for batter in (1, 2):
+            rows.append({"batter": batter, "season": season, "pa": 600,
+                         "k": 120, "age": 27, "partial": False})
+    rows.append({"batter": 1, "season": 2026, "pa": partial_pa,
+                 "k": round(partial_pa * partial_k_rate), "age": 28,
+                 "partial": True})
+    rows.append({"batter": 2, "season": 2026, "pa": 600, "k": 120,
+                 "age": 28, "partial": True})
+    return pd.DataFrame(rows)
+
+
+class TestBaselinesWithPartialSeasons:
+    spec = COMPONENTS["k_rate"]
+
+    def test_marcel_weights_the_partial_season_by_pa(self):
+        small = marcel(_train_frame(50), self.spec, 2026).set_index("batter")
+        big = marcel(_train_frame(500), self.spec, 2026).set_index("batter")
+        control = marcel_preseason(_train_frame(50), self.spec, 2026).set_index("batter")
+        # A hot partial season pulls the projection up, and 500 PA of it pulls
+        # ten times as hard as 50 — that is Marcel weighting by trials.
+        assert control.loc[1, "predicted"] < small.loc[1, "predicted"]
+        assert small.loc[1, "predicted"] < big.loc[1, "predicted"]
+
+    def test_marcel_preseason_ignores_the_partial_season(self):
+        hot = marcel_preseason(_train_frame(500), self.spec, 2026)
+        cold = marcel_preseason(_train_frame(500, partial_k_rate=0.05),
+                                self.spec, 2026)
+        pd.testing.assert_frame_equal(hot, cold)
+
+    def test_previous_season_uses_the_last_full_season(self):
+        pred = previous_season(_train_frame(500), self.spec, 2026).set_index("batter")
+        assert pred.loc[1, "predicted"] == pytest.approx(0.20)  # 2025, not 2026
+
+    def test_league_average_is_the_rate_through_the_cutoff(self):
+        # Batter 1 at .50 over 500 PA, batter 2 at .20 over 600 PA.
+        pred = league_average(_train_frame(500), self.spec, 2026)
+        expected = (250 + 120) / (500 + 600)
+        assert pred["predicted"].nunique() == 1
+        assert pred["predicted"].iloc[0] == pytest.approx(expected)
+
+    def test_season_to_date_regresses_with_the_component_ballast(self):
+        train = _train_frame(500)
+        pred = season_to_date(train, self.spec, 2026).set_index("batter")
+        league = (250 + 120) / 1100
+        b = SEASON_TO_DATE_BALLAST["k_rate"]
+        assert pred.loc[1, "predicted"] == pytest.approx(
+            (250 + b * league) / (500 + b))
+
+    def test_season_to_date_with_zero_pa_is_league_average(self):
+        train = _train_frame(500)
+        train = pd.concat([train, pd.DataFrame([
+            {"batter": 3, "season": 2026, "pa": 0, "k": 0,
+             "age": 28, "partial": True}])], ignore_index=True)
+        pred = season_to_date(train, self.spec, 2026).set_index("batter")
+        league = (250 + 120) / 1100
+        assert pred.loc[3, "predicted"] == pytest.approx(league)
+
+
+class TestBacktestWithCutoff:
+    """A synthetic 2026 season plus two prior seasons, cut at a date."""
+
+    @pytest.fixture
+    def pa(self):
+        """Three batters, 40 PA in each of April..August 2026.
+
+        K rates by batter: .15 / .25 / .35, identical before and after any
+        month boundary, so a cutoff never changes the truth being scored.
+        """
+        rows = []
+        for month in range(4, 9):
+            for batter, k in [(1, 6), (2, 10), (3, 14)]:
+                rows += pa_rows(
+                    batter, f"2026-0{month}-10",
+                    {"strikeout": k, "field_out": 40 - k}, game_pk=month,
+                )
+        return pd.DataFrame(rows)
+
+    @pytest.fixture
+    def seasons(self):
+        rows = []
+        for season in (2024, 2025):
+            for batter, rate in [(1, 0.15), (2, 0.25), (3, 0.35)]:
+                rows.append({"batter": batter, "season": season, "age": 27,
+                             "pa": 600, "k": int(round(rate * 600))})
+        return pd.DataFrame(rows)
+
+    def test_end_to_end(self, pa, seasons):
+        results = backtest("k_rate", cutoff_date="2026-07-01", seasons=seasons,
+                           pa_frame=pa, min_trials=50)
+        assert set(results["model"]) == {
+            "marcel", "marcel_preseason", "previous_season",
+            "league_average", "season_to_date"}
+        # Two months of 40 PA are scored, not the whole season.
+        assert results["trials"].max() == 80
+        s = score(results).set_index("model")
+        assert s.loc["previous_season", "mae"] < s.loc["league_average", "mae"]
+
+    def test_cutoff_before_first_game_matches_the_season_level_split(
+            self, pa, seasons
+    ):
+        """With nothing banked in-season the harness must reduce to the
+        season-level backtest on the same numbers."""
+        season_2026 = aggregate_pa(pa, 2026)
+        full = pd.concat([seasons, season_2026], ignore_index=True)
+        plain = backtest("k_rate", 2025, 2026, seasons=full, min_trials=50)
+        cut = backtest("k_rate", cutoff_date="2026-01-01", seasons=seasons,
+                       pa_frame=pa, min_trials=50,
+                       providers={"marcel": marcel,
+                                  "previous_season": previous_season,
+                                  "league_average": league_average})
+        cols = ["model", "batter", "predicted", "realized_successes",
+                "realized_rate", "trials"]
+        pd.testing.assert_frame_equal(
+            plain[cols].sort_values(["model", "batter"]).reset_index(drop=True),
+            cut[cols].sort_values(["model", "batter"]).reset_index(drop=True),
+        )
+
+    def test_cutoff_after_last_game_leaves_nothing_to_score(self, pa, seasons):
+        with pytest.raises(ValueError, match="realized frame is empty"):
+            backtest("k_rate", cutoff_date="2026-12-01", seasons=seasons,
+                     pa_frame=pa, min_trials=50)
+
+    def test_later_cutoff_scores_fewer_trials(self, pa, seasons):
+        trials = {}
+        for cutoff in ["2026-05-01", "2026-07-01", "2026-08-01"]:
+            r = backtest_intraseason("k_rate", cutoff, seasons=seasons,
+                                     pa_frame=pa, min_trials=1)
+            trials[cutoff] = int(r[r.model == "marcel"]["trials"].sum())
+        assert trials["2026-05-01"] > trials["2026-07-01"] > trials["2026-08-01"]
+
+    def test_pa_frame_required_with_a_cutoff(self, seasons):
+        with pytest.raises(ValueError, match="pa_frame"):
+            backtest("k_rate", cutoff_date="2026-07-01", seasons=seasons)
+
+    def test_pa_frame_rejected_without_a_cutoff(self, pa, seasons):
+        with pytest.raises(ValueError, match="only meaningful with cutoff_date"):
+            backtest("k_rate", 2025, seasons=seasons, pa_frame=pa)
+
+    def test_providers_never_see_post_cutoff_data(self, pa, seasons):
+        seen = {}
+
+        def spy(train, spec, predict_year):
+            seen["max_date"] = train["last_game_date"].max()
+            seen["max_season"] = int(train["season"].max())
+            return previous_season(train, spec, predict_year)
+
+        backtest("k_rate", cutoff_date="2026-07-01", seasons=seasons,
+                 pa_frame=pa, min_trials=50, providers={"spy": spy})
+        assert seen["max_season"] == 2026
+        assert seen["max_date"] < pd.Timestamp("2026-07-01")


### PR DESCRIPTION
BAS-43 / closes #26. The harness now answers the rest-of-season question. Implemented by an Opus subagent in an isolated worktree; the July-1 K% and BB% tables were reproduced in this session from the cached 2026 PA file.

## What it adds

`backtest(component, cutoff_date="2026-07-01", pa_frame=..., seasons=...)` — training = prior full seasons + the current season **through** the cutoff (flagged `partial`), realized = every PA on or after it, scored through the same `score` / `calibration` path as the season-level harness. `assert_split_clean` rejects a training PA on/after the cutoff, a realized PA before it, and any season leakage. All five components derive from the PA flags via the standard identities (nothing dropped; there is a regression test for the `int8` overflow trap on `3·HR`).

Baselines learn the partial season: `marcel` (partial season as the most recent year, weighted by PA), `marcel_preseason` (the same Marcel with no in-season data), `season_to_date` (own partial rate regressed to league), plus the existing `previous_season` / `league_average`. The existing Bayesian projections (fit through 2025, `data/projections/*_2026.parquet`) are scored as `bayes_preseason` — the "no in-season information" arm.

## Finding — MAE on the rest of 2026, common players, min 100 trials

| Component | Arm | May 1 | Jul 1 | Aug 1 |
|---|---|---|---|---|
| **K%** | marcel (with partial) | **.0278** | **.0296** | **.0343** |
| | marcel_preseason | .0293 | .0310 | .0365 |
| | bayes_preseason | .0296 | .0325 | .0386 |
| | season_to_date | .0355 | .0340 | .0371 |
| **BB%** | marcel | **.0172** | **.0206** | **.0268** |
| | marcel_preseason | .0179 | .0218 | .0275 |
| | bayes_preseason | .0179 | .0222 | .0279 |
| **HR/PA** | marcel | **.0098** | **.0115** | **.0152** |
| | marcel_preseason | .0098 | .0118 | .0155 |
| **ISO** | marcel | **.0345** | **.0413** | .0567 |
| | bayes_preseason | .0358 | .0436 | **.0551** |
| **BABIP** | marcel | **.0269** | .0350 | .0424 |

(n: K/BB/HR 315 · 231 · 126; ISO 308 · 213 · 80; BABIP 267 · 157 · **4** — the Aug-1 BABIP column is four players and means nothing.)

Three things fall out:

1. **In-season data helps, most where skill is most real.** Folding the current season into Marcel cuts rest-of-season K% error 4.6–6.1% and BB% 2.7–5.6% at every horizon; ISO 2–3.5% through July; HR/PA 2.3% from July; BABIP nothing at any cutoff. That is the reliability ordering K% > BB% > ISO ≈ HR > BABIP, confirmed within a season rather than across them.
2. **It is worth more than our model.** `bayes_preseason` never beats `marcel_preseason` on K% (tie in May, ~5% behind from July), while Marcel-with-partial beats our model by 6–11%. Five percent of K% MAE is about half the whole preseason Marcel-to-Depth-Charts spread, and it comes from not throwing April away.
3. **How you ingest it matters.** `season_to_date` loses to Marcel-with-partial on every component at every cutoff; the value is in adding the partial season to the multi-year prior, not replacing it.

Log loss orders the arms identically; Marcel-with-partial stays calibrated (K% July deciles within ±.018).

## What this means for the refit workflow

This is the harness the Modal refits will be judged by. The bar for a mid-season refit of the Bayesian components is no longer "beat preseason Marcel" — it is **beat Marcel that has seen the same partial season**, which currently sits 6–11% ahead of the preseason Bayesian arm on K%. Recorded in `docs/backtest-baselines.md` (new dated section).

## Files

Added `src/eval/intraseason.py`, `src/data/pa_outcomes.py` (cached R2 loader), `scripts/run_intraseason_backtest.py`, `tests/test_eval/test_intraseason.py` (25). Changed `src/eval/backtest.py` (extracted `_run_split`, shared), `src/eval/baselines.py`, `src/eval/__init__.py`, `docs/backtest-baselines.md`. Suite 295 passing.

Caveats: prior seasons come from the Stats API season table and the partial season from Statcast PA (~0.7% more PA per player), so a hair of the increment could be universe drift — only 2026 exists at PA level in R2 to close it. The 2026 PA file ends Sept 1. The doc's older season-level `previous_season` row does not reproduce today (stale snapshot, verified not a regression); left as-is since it predates this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_