### PR TITLE
Postseason bracket priced off rotations — up to 4.7 pts of pennant odds, above the noise floor

### DIFF
--- a/docs/playoff-odds-validation.md
+++ b/docs/playoff-odds-validation.md
@@ -126,12 +126,165 @@ matters where the remaining schedule is short relative to the decision:
 1. **The last week**, when a division race turns on three or four games and
    the fraction of remaining games with posted probables goes to ~1.
 2. **The postseason bracket**, where a seven-game series is decided by four
-   announced starters and rotation quality is most of the edge. The bracket
-   still runs on team strength today — nobody has announced a Game 1 starter
-   in early September — and wiring starters into `bracket.play_series` is the
-   natural follow-on once postseason rotations are set.
+   announced starters and rotation quality is most of the edge. ~~The bracket
+   still runs on team strength today.~~ **Wired the same day** — see
+   [the next section](#sept-2-2026--the-starter-term-reaches-the-postseason-bracket),
+   where it turns out to be the first version of this term big enough to
+   clear the simulation's own noise floor.
 3. **Per-game odds and prices**, which is where the term already earns its
    keep and where it is scored (station E, not station G).
 
 Being invisible here is the expected result, and it is why the gate for this
 change was the per-game Brier score and not this table.
+
+---
+
+## Sept 2, 2026 — the starter term reaches the postseason bracket
+
+The section above ends by naming the two places the starting-pitcher term was
+expected to matter and did not yet reach. This is the second of them: **the
+bracket now prices every game of every series off the arm whose turn it is.**
+
+Each club carries an ordered rotation — `(pitcher_id, RA/9 delta from league
+average)`, ace first — and `bracket.play_series` walks it game by game,
+wrapping after `--rotation-size` (default 4), so a best-of-7 starts the same
+pitcher in games 1 and 5. A club with no rotation is priced on team strength
+for its games; because the rotation enters as a *delta*, only the side that
+has one moves, exactly as in `starters.blend_starter_team`.
+
+The bracket is handed talent win%, not run rates, so `strength_with_starter`
+inverts Pythagenpat at the club's run environment, moves runs allowed by
+`5.5/9 · delta`, and converts back. The inversion is exact, so a
+league-average starter returns the club's strength unchanged to the last bit
+and `rotations=None` reproduces the pre-rotation bracket draw for draw.
+
+**Where the rotation comes from.** One rate table, the same one the
+regular-season overrides use (`run_playoff_odds.starter_terms` builds it
+once): the six pitchers with the most starts for the club this season, ranked
+by regressed FIP, best four kept. A postseason series already inside the
+7-day probables window is priced off the announced starters by the
+regular-season path; the bracket rotation is what fills in every series that
+has not been announced yet, which in early September is all of them.
+
+Reproduce:
+`python3 scripts/run_playoff_odds.py --sims 5000 --dry-run --cached-pitchers --rotation-compare`.
+
+**Run:** 2,089 games played, 342 remaining, HFA 0.5336, 5,000 sims, seed 245.
+27 of the 342 remaining games had both probables posted; all 30 clubs got a
+4-man rotation. Both runs below share the seed *and* the 27 regular-season
+overrides, so the only thing that differs is how the bracket prices a series.
+
+| | max abs Δ | team |
+|---|---|---|
+| **P(pennant)** | **4.68 pts** | CHC |
+| **P(World Series)** | **3.98 pts** | MIL |
+| P(playoffs) | 0.02 pts | BAL |
+
+P(playoffs) is untouched by construction — a rotation cannot change who
+reaches October, only who survives it — and the 0.02 is a single simulation
+whose wild-card tiebreaker landed differently.
+
+### Top 5 movers, with the arms that moved them
+
+| Team | Δ P(pennant) | Δ P(WS) | Game 1 | Δ RA/9 | Game 2 | Δ RA/9 |
+|---|---|---|---|---|---|---|
+| CHC | −4.68 | −2.94 | Shota Imanaga | −0.084 | Matthew Boyd | −0.035 |
+| CWS | −4.58 | −2.94 | Bryan Hudson | −0.129 | Sean Burke | −0.034 |
+| MIL | +2.98 | +3.98 | Jacob Misiorowski | −1.153 | Logan Henderson | −0.702 |
+| TB | +2.90 | +0.58 | Griffin Jax | −0.757 | Drew Rasmussen | −0.537 |
+| NYY | +2.20 | +0.94 | Cam Schlittler | −0.736 | Max Fried | −0.492 |
+
+The sign is the whole story. Milwaukee and Tampa Bay have the two arms at the
+top of the board and gain; the Cubs and the White Sox have staffs that
+regressed FIP puts within a tenth of a run of league average and lose, because
+in a short series they now face somebody else's ace twice with nothing to
+answer it. Team strength cannot see this at all: it prices a series off two
+season-long run differentials, which is the *rotation average*, and a
+rotation average is the wrong statistic for a seven-game series.
+
+### Unlike the regular-season term, this one clears the noise floor
+
+The lesson of the first starter section was that September playoff odds
+cannot resolve a term that reaches 27 of 344 games. This one is different,
+and the same test says so. Re-running the *unchanged* model at three seeds:
+
+| Compared | max abs Δ P(playoffs) | max abs Δ P(pennant) | max abs Δ P(WS) |
+|---|---|---|---|
+| seeds 245 vs 246 | 1.78 | 2.22 | 1.46 |
+| seeds 245 vs 247 | 0.94 | 1.64 | 0.64 |
+| seeds 246 vs 247 | 0.84 | 1.04 | 1.30 |
+| **rotations on/off, seed 245** | **0.02** | **4.68** | **3.98** |
+| **rotations on/off, seed 246** | **0.00** | **6.64** | **5.46** |
+
+Two things separate a real effect from sampling noise here, and both hold.
+The rotation swing is two to three times the seed-to-seed spread, and it
+**replicates**: run the on/off comparison again at seed 246 and the same
+clubs move the same way (CWS −6.64, MIL +5.78, CHC −5.18, TB +4.12,
+NYY +3.24). Noise does not name the same five teams twice.
+
+That it moves P(pennant) more than P(WS) is the mechanism showing through:
+the term compounds over three or four rounds, and by the World Series the
+biggest movers are meeting each other.
+
+### Against the market
+
+**Kalshi lists no `KXMLBSERIES` markets right now — none open, and none
+unopened, closed or settled either.** The series exists on the exchange but
+individual postseason series are not listed until the matchups are set, so
+there is nothing yet to score a series probability against. That comparison
+has to wait for October, and it is the one that matters for this term:
+`KXMLBSERIES` prices exactly the quantity the bracket now models.
+
+What *is* open and liquid is the season-long futures board — `KXMLB` (World
+Series, LAD 28.6/29.7¢, ~75k contracts in 24h), `KXMLBAL` and `KXMLBNL`
+(pennants) — 30 and 15 markets with one- and two-cent spreads. Comparing
+our P(pennant) and P(WS) to the yes-side mid (not de-vigged; the AL and NL
+pennant books sum to 1.025 and 1.030, the WS book to 0.995):
+
+| Mean abs gap vs Kalshi mid | all 30 | top 10 by WS price |
+|---|---|---|
+| P(pennant), bracket on team strength | 2.44 | 5.70 |
+| P(pennant), bracket on rotations | **2.27** | **5.14** |
+| P(WS), bracket on team strength | **1.48** | 3.91 |
+| P(WS), bracket on rotations | 1.51 | **4.01** |
+
+Rotations move us slightly *toward* the market on the pennant and slightly
+away on the World Series, and every one of those moves is smaller than the
+gap that was already there. Read it as "no contradiction", not as evidence
+either way: the board is dominated by two disagreements that predate this
+change and that the first section already diagnosed — we are 12 points under
+Kalshi on the Dodgers and 12–17 over on the Brewers, both of which trace to
+**team strength v0 being outcome-based rather than roster-based**, and
+rotations make the Milwaukee gap wider because Milwaukee also has the best
+arm on the board. This is a futures snapshot, not a score; the scoreable
+version is per-series prices in October.
+
+### What this first pass does not know
+
+The rotation is picked by a rule, not by a manager, and the rule is crude on
+purpose. Every one of these is visible in the September 2 pools:
+
+1. **Six-by-starts, then four-by-FIP.** The White Sox lead with Bryan Hudson,
+   who has 7 starts, ahead of Sean Burke's 26 — and a better arm with 5
+   starts fell outside the six-deep pool entirely. The pool guards against
+   ranking a reliever's 40 innings first; it does not guard against a
+   swingman with a dozen.
+2. **Openers and bullpen games** are counted as starts, so an opener can be
+   handed Game 1, and a club that plans to cover Game 4 with the bullpen is
+   modelled as starting somebody.
+3. **Order is by FIP, not by the manager.** The Yankees line up Schlittler
+   ahead of Cole and Fried. Regressed FIP may even be right; it is still not
+   what the lineup card will say.
+4. **Mid-season trades split a pitcher across both clubs**, so a July
+   acquisition looks shallower on his new team than he is.
+5. **Health, roster eligibility and rest are all invisible.** A club that
+   clinches early and lines its ace up on extra rest gets no credit; an
+   injured starter is still in the rotation.
+6. **Home-field advantage is not re-estimated per series**, and the delta is
+   applied at a league-average run environment where a club's own is unknown.
+
+The fix for 1-3 is the same fix: use the announced probables once the series
+is scheduled, which the code already prefers where they exist. Until then
+this is a rotation-shaped prior, and the honest claim for it is the one the
+numbers support — it is a *large* change to the postseason answer, and it is
+not yet scored against anything. `KXMLBSERIES` in October is the exam.

--- a/scripts/run_playoff_odds.py
+++ b/scripts/run_playoff_odds.py
@@ -13,11 +13,22 @@ probable starters the Stats API has already posted. Probables go up two to
 five days out, so a seven-day window catches all of them and most of the
 window is empty; games without both probables keep team strength, which is
 the correct rotation-average expectation for a game whose starters nobody
-has announced. `--no-starters` reverts to team strength everywhere.
+has announced.
+
+The same term prices the **postseason bracket**: each club carries an ordered
+rotation — its most-used starters this season, ranked by that same regressed
+FIP, ace first — and every game of every series is priced off the arm whose
+turn it is, cycling and wrapping after `--rotation-size` (default 4). A short
+series is 3-7 games off four announced arms, so this is where knowing the
+pitcher has the most room to move an answer.
+
+`--no-starters` reverts to team strength everywhere, regular season and
+bracket alike.
 
 Usage:
     python scripts/run_playoff_odds.py --sims 20000
     python scripts/run_playoff_odds.py --sims 2000 --dry-run   # print only
+    python scripts/run_playoff_odds.py --sims 5000 --dry-run --rotation-compare
 """
 from __future__ import annotations
 
@@ -29,10 +40,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+import numpy as np
 import pandas as pd
 
 from src.data.mlb_stats_api import fetch_probables, fetch_schedule, fetch_standings
 from src.sim import starters as sp_model
+from src.sim.bracket import DEFAULT_ROTATION_SIZE, Rotations
 from src.sim.odds import run_playoff_odds
 from src.sim.season import SeasonState, from_schedule
 from src.sim.strength import (
@@ -45,55 +58,140 @@ OUT_DIR = Path(__file__).resolve().parent.parent / "public/data/playoff_odds"
 
 BASE_METHOD = "Regressed Pythagenpat strength, log5 + HFA, MLB tiebreakers"
 SP_METHOD = (BASE_METHOD + "; pythag_60_sp starting-pitcher term on remaining "
-             "games with both probables posted")
+             "games with both probables posted, and on every postseason series "
+             "game from each club\'s regressed-FIP rotation")
 # Probables are posted ~2-5 days ahead, so a week covers every game that has
 # them and costs one extra schedule call for the empty tail.
 STARTER_WINDOW_DAYS = 7
+# How many pitchers beyond the rotation to rank by FIP. Two is enough to let
+# the rank pick around a swingman without reaching into September call-ups.
+ROTATION_POOL_EXTRA = 2
 
 
-def starter_overrides(
-    season: int, state: SeasonState, standings: pd.DataFrame, hfa: float,
-    regress_games: float, as_of: date, window_days: int = STARTER_WINDOW_DAYS,
-    refresh: bool = True,
-) -> tuple[dict[int, float], dict]:
-    """{game_pk: P(home)} for remaining games with both starters announced.
+def _rotation_candidates(probables: pd.DataFrame, schedule: pd.DataFrame,
+                         as_of: date, pool: int) -> dict[int, list[int]]:
+    """team_id -> the `pool` pitchers who have started most for it this season.
 
-    Runs exactly the chain `scripts/backtest_game_odds.py` scores as
-    `pythag_60_sp`, through the same functions: team RS/RA regressed the same
-    60 games the production strength uses → each side's runs allowed moved by
-    how far its announced starter's regressed FIP sits from league average
-    over the 5.5 innings he covers → Pythagenpat → log5 → HFA. The backtest
-    walks it over a whole season and this walks it over one date; both call
-    `starters.rate_table` and `starters.game_home_prob`, so the live number and
-    the scored number cannot drift apart.
+    `fetch_probables` serves the pitcher who *actually* started for a date in
+    the past (see its docstring), so the season-to-date probables feed joined
+    to the schedule's team ids is a start log. Only starts strictly before
+    `as_of` count — the same date cut `starters.rate_table` applies to the
+    rates — and only regular-season games, so an earlier postseason round
+    cannot feed itself.
 
-    `refresh` re-pulls today's probables and the season's pitcher game logs
-    rather than trusting caches keyed by season (see `starters.rate_inputs`).
+    Starts are counted for the team the pitcher started *for*, so a mid-season
+    trade splits his season across both clubs; a pitcher acquired in July
+    therefore looks shallower on his new team than he is. That is one of the
+    first-pass simplifications listed in docs/playoff-odds-validation.md.
+    """
+    past = probables[(probables["game_type"] == "R")
+                     & (probables["date"].astype(str) < as_of.isoformat())]
+    past = past.merge(schedule[["game_pk", "home_id", "away_id"]], on="game_pk")
+    sides = []
+    for sp_col, team_col in (("home_sp_id", "home_id"), ("away_sp_id", "away_id")):
+        part = past.dropna(subset=[sp_col])[[team_col, sp_col]]
+        part.columns = ["team_id", "pitcher"]
+        sides.append(part)
+    starts = pd.concat(sides, ignore_index=True)
+    if starts.empty:
+        return {}
+    starts = starts.astype({"team_id": "int64", "pitcher": "int64"})
+    counts = (starts.groupby(["team_id", "pitcher"]).size()
+              .rename("starts").reset_index()
+              .sort_values(["team_id", "starts"], ascending=[True, False]))
+    return {int(t): [int(x) for x in g["pitcher"].head(pool)]
+            for t, g in counts.groupby("team_id")}
 
-    Returns (overrides, diagnostics).
+
+def build_rotations(candidates: dict[int, list[int]], sp_ra9: dict,
+                    lg_ra9: float, index_of: dict[int, int],
+                    run_env: np.ndarray, rotation_size: int) -> Rotations:
+    """`bracket.Rotations` from the same rate table the game overrides use.
+
+    Each club's candidate pool (the pitchers with the most starts for it this
+    season) is ranked by regressed FIP and the best `rotation_size` become the
+    rotation, ace first — which is how a postseason rotation is actually set,
+    and the reason the pool is built by starts rather than by FIP alone: it
+    keeps a reliever with 40 good innings out of Game 1. Pitchers absent from
+    the rate table have no history and sit at league average, a zero delta.
+
+    Deliberately a first pass. It does not know about openers, a starter left
+    off the roster, a club that clinches early and lines its ace up on extra
+    rest, or a Game 4 covered by the bullpen. See
+    docs/playoff-odds-validation.md.
+    """
+    by_team: dict[int, list[tuple[int, float]]] = {}
+    for team_id, pool in candidates.items():
+        row = index_of.get(int(team_id))
+        if row is None or not pool:
+            continue
+        ranked = sorted(pool, key=lambda pid: sp_ra9.get(int(pid), lg_ra9))
+        by_team[row] = [(int(pid), float(sp_ra9.get(int(pid), lg_ra9)) - lg_ra9)
+                        for pid in ranked[:rotation_size]]
+    return Rotations(by_team=by_team, lg_ra9=lg_ra9, run_env=run_env)
+
+
+def starter_terms(
+    season: int, state: SeasonState, standings: pd.DataFrame,
+    schedule: pd.DataFrame, hfa: float, regress_games: float, as_of: date,
+    window_days: int = STARTER_WINDOW_DAYS,
+    rotation_size: int = DEFAULT_ROTATION_SIZE, refresh: bool = True,
+) -> tuple[dict[int, float], Rotations, dict]:
+    """Both starter terms off **one** rate table: game overrides and rotations.
+
+    Returns `({game_pk: P(home)}, Rotations, diagnostics)`.
+
+    *Regular season.* Exactly the chain `scripts/backtest_game_odds.py` scores
+    as `pythag_60_sp`, through the same functions: team RS/RA regressed the
+    same 60 games the production strength uses -> each side's runs allowed
+    moved by how far its announced starter's regressed FIP sits from league
+    average over the 5.5 innings he covers -> Pythagenpat -> log5 -> HFA. The
+    backtest walks it over a whole season and this walks it over one date;
+    both call `starters.rate_table` and `starters.game_home_prob`, so the live
+    number and the scored number cannot drift apart.
+
+    *Postseason.* The bracket gets each club's rotation as ordered
+    `(pitcher_id, RA/9 delta)` pairs, from the same rate table — the pool is
+    the season's most-used starters, the order is regressed FIP. A short
+    series is 3-7 games off four announced arms, which is where the term has
+    the most room to move an answer.
+
+    One `fetch_probables` call covers both — the season to date for the start
+    log and the next `window_days` for the announcements — and one
+    `starters.rate_inputs` fetch covers every pitcher either term names, so
+    the two terms cannot be built on different rates.
+
+    `refresh` re-pulls probables and the season's pitcher game logs rather
+    than trusting caches keyed by season (see `starters.rate_inputs`).
     """
     end = as_of + timedelta(days=window_days)
-    probables = fetch_probables(as_of.isoformat(), end.isoformat(), refresh=refresh)
-    probables = probables.dropna(subset=["home_sp_id", "away_sp_id"])
+    probables = fetch_probables(f"{season}-03-01", end.isoformat(), refresh=refresh)
 
     # Only games the simulator is actually still drawing. This drops spring
     # and postseason game types, anything already final, and — importantly —
     # tonight's games if they have started, since those leave `remaining`.
     remaining = {int(r.game_pk): (int(r.home_id), int(r.away_id))
                  for r in state.remaining.itertuples(index=False)}
-    probables = probables[probables["game_pk"].astype(int).isin(remaining)]
-    diag = {"n_games_with_starters": 0, "starter_window_days": window_days,
-            "sp_no_history": 0}
-    if probables.empty:
-        return {}, diag
-
+    window = probables.dropna(subset=["home_sp_id", "away_sp_id"])
+    window = window[window["game_pk"].astype(int).isin(remaining)]
     pmap = {int(r.game_pk): (int(r.home_sp_id), int(r.away_sp_id))
-            for r in probables.itertuples(index=False)}
+            for r in window.itertuples(index=False)}
+
+    # The candidate pool is a couple deeper than the rotation so the FIP rank
+    # has something to choose from without reaching into September call-ups.
+    candidates = _rotation_candidates(probables, schedule, as_of,
+                                      pool=rotation_size + ROTATION_POOL_EXTRA)
+
     team = regressed_run_rates(standings, regress_games=regress_games)
     lg_ra9 = league_ra_per_game(standings)
-    sp_ra9 = sp_model.build_rate_table(
-        as_of.isoformat(), {p for ids in pmap.values() for p in ids},
-        season, lg_ra9, refresh=refresh)
+    pitcher_ids = {p for ids in pmap.values() for p in ids}
+    pitcher_ids |= {p for pool in candidates.values() for p in pool}
+    sp_ra9 = sp_model.build_rate_table(as_of.isoformat(), pitcher_ids, season,
+                                       lg_ra9, refresh=refresh)
+
+    diag = {"n_games_with_starters": 0, "starter_window_days": window_days,
+            "sp_no_history": 0, "rotation_size": rotation_size,
+            "n_teams_with_rotation": 0}
 
     overrides = {}
     for game_pk, sp_ids in pmap.items():
@@ -105,7 +203,27 @@ def starter_overrides(
         overrides[game_pk] = p_home
         diag["sp_no_history"] += no_history
     diag["n_games_with_starters"] = len(overrides)
-    return overrides, diag
+
+    run_env = ((team["rs_pg"] + team["ra_pg"])
+               .reindex(state.team_ids).to_numpy(dtype=float))
+    rotations = build_rotations(candidates, sp_ra9, lg_ra9, state.index_of(),
+                                run_env, rotation_size)
+    diag["n_teams_with_rotation"] = len(rotations.by_team)
+    return overrides, rotations, diag
+
+
+def rotation_table(rotations: Rotations, teams: pd.DataFrame) -> pd.DataFrame:
+    """One row per club: its rotation, ace first, with each starter's RA/9 delta."""
+    abbrev = teams["abbrev"].to_numpy()
+    rows = []
+    for row, rot in sorted(rotations.by_team.items(),
+                           key=lambda kv: kv[1][0][1] if kv[1] else 0.0):
+        entry = {"abbrev": abbrev[row]}
+        for i, (pid, delta) in enumerate(rot, start=1):
+            entry[f"g{i}_sp"] = pid
+            entry[f"g{i}_ra9d"] = round(delta, 3)
+        rows.append(entry)
+    return pd.DataFrame(rows)
 
 
 def override_effect(state: SeasonState, strength: pd.Series, hfa: float,
@@ -157,18 +275,27 @@ def format_odds(odds: pd.DataFrame) -> pd.DataFrame:
     return show
 
 
+COMPARE_PROBS = ("p_playoffs", "p_pennant", "p_ws")
+
+
 def compare(base: pd.DataFrame, sp: pd.DataFrame) -> pd.DataFrame:
-    """Per-team with/without table: the same seed, so every difference is the term."""
-    cols = ["abbrev", "division", "wins", "losses", "mean_wins", "p_playoffs", "p_ws"]
-    cmp = base[cols].merge(sp[["abbrev", "mean_wins", "p_playoffs", "p_ws"]],
-                           on="abbrev", suffixes=("", "_sp"))
-    for c in ("mean_wins", "p_playoffs", "p_ws"):
+    """Per-team with/without table: the same seed, so every difference is the term.
+
+    P(pennant) is carried alongside P(playoffs) and P(WS) because the bracket
+    term moves the pennant round first — a rotation cannot change who makes
+    October, only who survives it.
+    """
+    keep = ["mean_wins", *COMPARE_PROBS]
+    cols = ["abbrev", "division", "wins", "losses", *keep]
+    cmp = base[cols].merge(sp[["abbrev", *keep]], on="abbrev",
+                           suffixes=("", "_sp"))
+    for c in keep:
         cmp[f"d_{c}"] = cmp[f"{c}_sp"] - cmp[c]
     # Probabilities in percentage points, wins in wins; two decimals either way
     # because the differences live in the second one.
-    for c in ("p_playoffs", "p_playoffs_sp", "d_p_playoffs",
-              "p_ws", "p_ws_sp", "d_p_ws"):
-        cmp[c] = (cmp[c] * 100).round(2)
+    for c in COMPARE_PROBS:
+        for name in (c, f"{c}_sp", f"d_{c}"):
+            cmp[name] = (cmp[name] * 100).round(2)
     for c in ("mean_wins", "mean_wins_sp", "d_mean_wins"):
         cmp[c] = cmp[c].round(2)
     return cmp.sort_values("p_ws_sp", ascending=False).reset_index(drop=True)
@@ -183,11 +310,21 @@ def main() -> None:
                              "day reproduce)")
     parser.add_argument("--regress-games", type=float, default=60.0)
     parser.add_argument("--no-starters", action="store_true",
-                        help="ignore posted probables; price every remaining "
-                             "game off team strength alone (the pre-station-E "
-                             "production model)")
+                        help="ignore posted probables and postseason "
+                             "rotations; price every remaining game and every "
+                             "series game off team strength alone (the "
+                             "pre-station-E production model)")
     parser.add_argument("--starter-window-days", type=int, default=STARTER_WINDOW_DAYS,
                         help="how far ahead to look for posted probables")
+    parser.add_argument("--rotation-size", type=int, default=DEFAULT_ROTATION_SIZE,
+                        help="how many starters a postseason rotation carries "
+                             "before it wraps (game 1 = the club's best by "
+                             "regressed FIP)")
+    parser.add_argument("--rotation-compare", action="store_true",
+                        help="also run the bracket with the rotations removed "
+                             "and print the difference, isolating the "
+                             "postseason term from the regular-season one "
+                             "(one extra Monte Carlo pass)")
     parser.add_argument("--cached-pitchers", action="store_true",
                         help="reuse cached probables and pitcher game logs "
                              "instead of re-pulling them. Faster for repeated "
@@ -211,57 +348,99 @@ def main() -> None:
           f"HFA={hfa:.4f}, sims={args.sims}, seed={seed}")
 
     overrides: dict[int, float] = {}
+    rotations: Rotations | None = None
     diag = {"n_games_with_starters": 0, "sp_no_history": 0,
-            "starter_window_days": args.starter_window_days}
+            "starter_window_days": args.starter_window_days,
+            "rotation_size": args.rotation_size, "n_teams_with_rotation": 0}
     if not args.no_starters:
         try:
-            overrides, diag = starter_overrides(
-                args.season, state, standings, hfa, args.regress_games, today,
+            overrides, rotations, diag = starter_terms(
+                args.season, state, standings, schedule, hfa,
+                args.regress_games, today,
                 window_days=args.starter_window_days,
+                rotation_size=args.rotation_size,
                 refresh=not args.cached_pitchers)
         except Exception as exc:   # noqa: BLE001 — the nightly job must still ship odds
+            overrides, rotations = {}, None
             print(f"WARNING: starting-pitcher term unavailable ({exc!r}); "
-                  f"falling back to team strength on every remaining game")
+                  f"falling back to team strength on every remaining game "
+                  f"and on every postseason series")
         else:
             print(f"starters: {diag['n_games_with_starters']} of "
                   f"{len(state.remaining)} remaining games have both probables "
                   f"posted in the next {args.starter_window_days} days "
                   f"({diag['sp_no_history']} starter slots had no history, "
                   f"scored at league average)")
+            print(f"rotations: {diag['n_teams_with_rotation']} clubs carry a "
+                  f"{args.rotation_size}-man postseason rotation, ace first "
+                  f"(RA/9 delta from league; negative is better)")
+            print(rotation_table(rotations, state.teams).to_string(index=False))
 
-    # Same seed both ways, so the draw is identical on every game the overrides
-    # do not touch and the whole difference in the table below is the term.
+    has_rotations = rotations is not None and bool(rotations.by_team)
+
+    # Same seed everywhere, so the draw is identical on every game and every
+    # series the terms do not touch and the whole difference in the tables
+    # below is the term.
     base = run_playoff_odds(state, strength, hfa, n_sims=args.sims, seed=seed)
     base["division"] = base["division_id"].map(DIVISION_NAMES)
-    if overrides:
+    if overrides or has_rotations:
         odds = run_playoff_odds(state, strength, hfa, n_sims=args.sims, seed=seed,
-                                p_home_overrides=overrides)
+                                p_home_overrides=overrides or None,
+                                rotations=rotations if has_rotations else None)
         odds["division"] = odds["division_id"].map(DIVISION_NAMES)
     else:
         odds = base
 
     print(f"\n─── without the starter term (team strength on all "
-          f"{len(state.remaining)} remaining games) ───")
+          f"{len(state.remaining)} remaining games and every postseason "
+          f"series) ───")
     print(format_odds(base).to_string(index=False))
 
-    if overrides:
-        print(f"\n─── with the starter term on {len(overrides)} games "
-              f"({SP_METHOD.split('; ')[1]}) ───")
+    if odds is not base:
+        print(f"\n─── with the starter term: {len(overrides)} regular-season "
+              f"games repriced, {diag['n_teams_with_rotation']} postseason "
+              f"rotations ───")
         print(format_odds(odds).to_string(index=False))
         cmp = compare(base, odds)
         print("\n─── with vs without, same seed (percentage points) ───")
         print(cmp.to_string(index=False))
-        print(f"\nmax |Δ p_playoffs| = {cmp['d_p_playoffs'].abs().max():.2f} pts "
-              f"({cmp.loc[cmp['d_p_playoffs'].abs().idxmax(), 'abbrev']})")
-        print(f"max |Δ p_ws|        = {cmp['d_p_ws'].abs().max():.2f} pts "
-              f"({cmp.loc[cmp['d_p_ws'].abs().idxmax(), 'abbrev']})")
-        print(f"max |Δ mean wins|   = {cmp['d_mean_wins'].abs().max():.2f} "
-              f"({cmp.loc[cmp['d_mean_wins'].abs().idxmax(), 'abbrev']})")
+        for col, label in (("d_p_playoffs", "p_playoffs"),
+                           ("d_p_pennant", "p_pennant"), ("d_p_ws", "p_ws"),
+                           ("d_mean_wins", "mean wins")):
+            print(f"max |Δ {label}| = {cmp[col].abs().max():.2f} "
+                  f"({cmp.loc[cmp[col].abs().idxmax(), 'abbrev']})")
 
-        # The two tables above are two Monte Carlo runs; in September their
+    # The bracket term on its own: the same run with the rotations removed, so
+    # the regular-season overrides are held fixed and the only thing that moves
+    # is how the postseason series are priced.
+    if args.rotation_compare and has_rotations:
+        flat = run_playoff_odds(state, strength, hfa, n_sims=args.sims, seed=seed,
+                                p_home_overrides=overrides or None)
+        flat["division"] = flat["division_id"].map(DIVISION_NAMES)
+        rot_cmp = compare(flat, odds)
+        print("\n─── postseason rotations only: bracket on team strength vs "
+              "on the rotation, same seed (percentage points) ───")
+        print(rot_cmp.to_string(index=False))
+        for col, label in (("d_p_pennant", "p_pennant"), ("d_p_ws", "p_ws")):
+            print(f"max |Δ {label}| = {rot_cmp[col].abs().max():.2f} "
+                  f"({rot_cmp.loc[rot_cmp[col].abs().idxmax(), 'abbrev']})")
+        movers = rot_cmp.reindex(rot_cmp["d_p_pennant"].abs()
+                                 .sort_values(ascending=False).index).head(5)
+        print("\ntop 5 movers on P(pennant), with their game-1/game-2 starters:")
+        abbrev_row = {a: i for i, a in enumerate(state.teams["abbrev"])}
+        for r in movers.itertuples(index=False):
+            rot = rotations.by_team.get(abbrev_row[r.abbrev], [])
+            arms = ", ".join(f"g{i}: {pid} {d:+.3f}"
+                             for i, (pid, d) in enumerate(rot[:2], start=1))
+            print(f"  {r.abbrev}: Δp_pennant {r.d_p_pennant:+.2f} pts, "
+                  f"Δp_ws {r.d_p_ws:+.2f} pts  [{arms}]")
+
+    if overrides:
+        # The odds tables above are Monte Carlo runs; in September their
         # difference is smaller than the sim noise. This part is exact.
         effect = override_effect(state, strength, hfa, overrides)
-        print(f"\n─── the term itself, in closed form (no sampling) ───")
+        print(f"\n─── the regular-season term itself, in closed form (no "
+              f"sampling) ───")
         print(f"{len(effect)} games repriced: mean |Δ P(home)| = "
               f"{effect['delta'].abs().mean():.4f}, max = "
               f"{effect['delta'].abs().max():.4f}")
@@ -283,7 +462,9 @@ def main() -> None:
         "games_remaining": int(len(state.remaining)),
         "n_games_with_starters": int(diag["n_games_with_starters"]),
         "starter_window_days": int(diag["starter_window_days"]),
-        "method": SP_METHOD if overrides else BASE_METHOD,
+        "n_teams_with_rotation": int(diag["n_teams_with_rotation"]),
+        "rotation_size": int(diag["rotation_size"]) if has_rotations else 0,
+        "method": (SP_METHOD if odds is not base else BASE_METHOD),
         "teams": json.loads(odds.drop(columns=["division_id"]).to_json(orient="records")),
     }
     args.out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/sim/bracket.py
+++ b/src/sim/bracket.py
@@ -5,14 +5,27 @@ is best-of-3, all games at the higher seed: 3 v 6 and 4 v 5. Division
 Series best-of-5 (2-2-1): 1 v winner(4/5), 2 v winner(3/6). LCS best-of-7
 (2-3-2). World Series best-of-7 (2-3-2), home field to the better regular
 season record.
+
+**Rotations (station E in the bracket).** A series is 3-7 games with a known
+rotation, so who starts is a bigger share of the answer here than anywhere in
+the regular season. `play_series` / `play_postseason` take an optional
+`Rotations`: per team, an ordered list of `(pitcher_id, RA/9 delta from league
+average)` from the starter model. Game 1 uses the first entry, game 2 the
+second, wrapping after the rotation's own length (a 4-man rotation starts the
+same pitcher in games 1 and 5). A team with no rotation is priced on team
+strength for every game of the series, and because the rotation enters as a
+*delta* from league average, only the side that has one moves — exactly the
+property that lets `starters.blend_starter_team` mix a park- and
+defense-neutral FIP with a team rate that is neither.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 
-from src.sim.strength import home_win_prob
+from src.sim.starters import GAME_IP, MIN_RA9, STARTER_IP
+from src.sim.strength import PYTHAGENPAT_EXP, home_win_prob, pythagenpat
 
 SERIES_HOME_PATTERNS = {
     # wins needed → which games the higher seed hosts (1-indexed)
@@ -21,18 +34,140 @@ SERIES_HOME_PATTERNS = {
     4: {1, 2, 6, 7},         # best-of-7: 2-3-2
 }
 
+# Games a rotation is asked to cover before it wraps. Four is the modern
+# postseason default: teams that carry five in the regular season drop to four
+# in October because the off days let the top of the rotation take the extra
+# start.
+DEFAULT_ROTATION_SIZE = 4
+
+
+def strength_with_starter(p: float, ra9_delta: float, run_env: float,
+                          starter_ip: float = STARTER_IP) -> float:
+    """Talent win% `p`, moved by a starter sitting `ra9_delta` from league average.
+
+    The regular-season term (`starters.blend_starter_team`) works on the team's
+    runs-allowed rate and then runs Pythagenpat. The bracket is handed talent
+    win% instead, so this inverts Pythagenpat at the team's run environment
+    `run_env` (runs scored + allowed per game) to recover the implied RS/RA,
+    moves runs allowed by `starter_ip/9 · ra9_delta` — the same weighting and
+    the same delta form — and converts back.
+
+    The inversion is exact, so `ra9_delta == 0` returns `p` unchanged to the
+    last bit. That is what makes the no-rotation path in `play_series` byte
+    identical to the pre-rotation model, and it is why the fallback can be
+    per *team* rather than per matchup: a side without a rotation contributes
+    its unmodified strength.
+    """
+    if ra9_delta == 0.0:
+        return float(p)
+    x = float(run_env) ** PYTHAGENPAT_EXP
+    ratio = (p / (1.0 - p)) ** (1.0 / x)          # implied RS/RA
+    ra = float(run_env) / (1.0 + ratio)
+    rs = float(run_env) - ra
+    ra_sp = max(ra + (float(starter_ip) / GAME_IP) * float(ra9_delta), MIN_RA9)
+    return pythagenpat(rs, ra_sp, 1.0)
+
+
+@dataclass(frozen=True)
+class Rotations:
+    """Ordered postseason rotations, keyed by the team's row index.
+
+    `by_team[i]` is `[(pitcher_id, ra9_delta), ...]` — the delta being the
+    pitcher's regressed FIP (as runs allowed per 9) minus the league's runs
+    allowed per 9, i.e. negative for a pitcher better than average. Teams
+    absent from `by_team` are priced on team strength.
+
+    `run_env` is optional per-team runs scored + allowed per game (row-index
+    aligned with `strength`); without it every team is assumed to play in a
+    league-average environment of `2 · lg_ra9`, which affects only how much a
+    given RA/9 delta bends the win probability, never the baseline.
+    """
+    by_team: dict[int, list[tuple[int, float]]]
+    lg_ra9: float
+    run_env: np.ndarray | None = None
+    starter_ip: float = STARTER_IP
+    # Memo for `series_game_probs`, keyed by (higher seed, lower seed, wins
+    # needed). Every simulation in a run shares one `Rotations`, one strength
+    # vector and one HFA, so a matchup's table is computed once for the whole
+    # 20,000-sim job instead of once per series. Reusing a `Rotations` across
+    # runs with a *different* strength vector would serve stale tables, so
+    # build a new one per run (`run_playoff_odds.starter_terms` does).
+    _cache: dict = field(default_factory=dict, repr=False, compare=False)
+
+    def starter(self, team: int, game_idx: int) -> tuple[int, float] | None:
+        """`(pitcher_id, ra9_delta)` for game `game_idx` (0-based), or None."""
+        rot = self.by_team.get(int(team))
+        if not rot:
+            return None
+        return tuple(rot[game_idx % len(rot)])
+
+    def adjusted(self, team: int, game_idx: int, p: float) -> float:
+        """Team strength for game `game_idx`, moved by that game's starter."""
+        sp = self.starter(team, game_idx)
+        if sp is None:
+            return float(p)
+        env = (2.0 * self.lg_ra9 if self.run_env is None
+               else float(self.run_env[int(team)]))
+        return strength_with_starter(p, float(sp[1]), env,
+                                     starter_ip=self.starter_ip)
+
+
+def series_game_probs(high: int, low: int, wins_needed: int,
+                      strength: np.ndarray, hfa: float,
+                      rotations: Rotations | None = None,
+                      ) -> tuple[np.ndarray, np.ndarray]:
+    """P(higher seed wins) for each game of the series, hosting and visiting.
+
+    A series is at most `2·wins_needed − 1` games and both rotations are known
+    up front, so the whole matchup collapses to two short vectors indexed by
+    game number: one for the games the higher seed hosts and one for the games
+    it visits. `play_series` then only draws uniforms — no per-game strength
+    arithmetic inside the loop, and nothing that scales with the number of
+    simulations.
+
+    With no rotation on either side every game has the same probability, so
+    the vectors are length 1 and the caller indexes them modulo their length.
+    """
+    n_games = 2 * wins_needed - 1
+    key = (int(high), int(low), wins_needed)
+    if rotations is not None and key in rotations._cache:
+        return rotations._cache[key]
+    has_rot = rotations is not None and (
+        rotations.by_team.get(int(high)) or rotations.by_team.get(int(low)))
+    if not has_rot:
+        flat = (np.array([home_win_prob(strength[high], strength[low], hfa)]),
+                np.array([1 - home_win_prob(strength[low], strength[high], hfa)]))
+        if rotations is not None:
+            rotations._cache[key] = flat
+        return flat
+    at_home = np.empty(n_games)
+    on_road = np.empty(n_games)
+    for g in range(n_games):
+        s_high = rotations.adjusted(high, g, strength[high])
+        s_low = rotations.adjusted(low, g, strength[low])
+        at_home[g] = home_win_prob(s_high, s_low, hfa)
+        on_road[g] = 1 - home_win_prob(s_low, s_high, hfa)
+    rotations._cache[key] = (at_home, on_road)
+    return at_home, on_road
+
 
 def play_series(high: int, low: int, wins_needed: int, strength: np.ndarray,
-                hfa: float, rng: np.random.Generator) -> int:
-    """Simulate a series; returns the winning team's row index."""
+                hfa: float, rng: np.random.Generator,
+                rotations: Rotations | None = None) -> int:
+    """Simulate a series; returns the winning team's row index.
+
+    One uniform is drawn per game, in game order, whether or not rotations are
+    supplied — so a given seed produces the same draws as before and the
+    no-rotation path reproduces the pre-rotation model exactly.
+    """
     hosts = SERIES_HOME_PATTERNS[wins_needed]
+    at_home, on_road = series_game_probs(high, low, wins_needed, strength, hfa,
+                                         rotations)
     w_high = w_low = 0
     game = 1
     while w_high < wins_needed and w_low < wins_needed:
-        if game in hosts:
-            p_high = home_win_prob(strength[high], strength[low], hfa)
-        else:
-            p_high = 1 - home_win_prob(strength[low], strength[high], hfa)
+        table = at_home if game in hosts else on_road
+        p_high = table[(game - 1) % len(table)]
         if rng.random() < p_high:
             w_high += 1
         else:
@@ -49,20 +184,27 @@ class PostseasonResult:
 
 def play_postseason(seeds_by_league: dict[int, list[int]], reg_wins: np.ndarray,
                     strength: np.ndarray, hfa: float,
-                    rng: np.random.Generator) -> PostseasonResult:
+                    rng: np.random.Generator,
+                    rotations: Rotations | None = None) -> PostseasonResult:
+    """Both leagues' brackets plus the World Series.
+
+    `rotations` (optional) prices each game of every series with the starter
+    scheduled to pitch it; see `Rotations`.
+    """
     pennants = {}
     for league_id, seeds in seeds_by_league.items():
         s1, s2, s3, s4, s5, s6 = seeds
-        w45 = play_series(s4, s5, 2, strength, hfa, rng)
-        w36 = play_series(s3, s6, 2, strength, hfa, rng)
-        d1 = play_series(s1, w45, 3, strength, hfa, rng)
-        d2 = play_series(s2, w36, 3, strength, hfa, rng)
+        w45 = play_series(s4, s5, 2, strength, hfa, rng, rotations)
+        w36 = play_series(s3, s6, 2, strength, hfa, rng, rotations)
+        d1 = play_series(s1, w45, 3, strength, hfa, rng, rotations)
+        d2 = play_series(s2, w36, 3, strength, hfa, rng, rotations)
         # Higher seed hosts the LCS
         hi, lo = (d1, d2) if seeds.index(d1) < seeds.index(d2) else (d2, d1)
-        pennants[league_id] = play_series(hi, lo, 4, strength, hfa, rng)
+        pennants[league_id] = play_series(hi, lo, 4, strength, hfa, rng, rotations)
     a, b = list(pennants.values())
     if reg_wins[a] > reg_wins[b] or (reg_wins[a] == reg_wins[b] and rng.random() < 0.5):
         hi, lo = a, b
     else:
         hi, lo = b, a
-    return PostseasonResult(pennants, play_series(hi, lo, 4, strength, hfa, rng))
+    return PostseasonResult(
+        pennants, play_series(hi, lo, 4, strength, hfa, rng, rotations))

--- a/src/sim/odds.py
+++ b/src/sim/odds.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from src.sim.bracket import play_postseason
+from src.sim.bracket import Rotations, play_postseason
 from src.sim.season import SeasonState, simulate_remaining, tally
 from src.sim.standings import TiebreakContext, seed_league
 from src.sim.teams import AL, NL
@@ -16,11 +16,15 @@ def run_playoff_odds(
     state: SeasonState, strength: pd.Series, hfa: float,
     n_sims: int = 20_000, seed: int = 0,
     p_home_overrides: dict[int, float] | None = None,
+    rotations: Rotations | None = None,
 ) -> pd.DataFrame:
     """`p_home_overrides` (game_pk → P(home)) replaces the log5 probability for
-    the remaining games it names; see `season.simulate_remaining`. The
-    postseason bracket still runs on team strength — nobody has announced a
-    Game 1 starter in September."""
+    the remaining games it names; see `season.simulate_remaining`.
+
+    `rotations` (row index → ordered [(pitcher_id, RA/9 delta)]) prices each
+    game of every postseason series with the starter scheduled to pitch it
+    (`bracket.Rotations`). Teams it omits are priced on team strength, and
+    with `rotations=None` the bracket is the pre-rotation model exactly."""
     rng = np.random.default_rng(seed)
     home_wins = simulate_remaining(state, strength, hfa, n_sims, rng,
                                    p_home_overrides=p_home_overrides)
@@ -44,7 +48,7 @@ def run_playoff_odds(
                 counts["playoffs"][t] += 1
         post = play_postseason(
             {lg: sd.seeds for lg, sd in seeds.items()},
-            records.wins[s], strength_arr, hfa, rng,
+            records.wins[s], strength_arr, hfa, rng, rotations,
         )
         for t in post.pennant.values():
             counts["pennant"][t] += 1

--- a/tests/test_sim/test_bracket_starters.py
+++ b/tests/test_sim/test_bracket_starters.py
@@ -1,0 +1,213 @@
+"""Postseason rotations in the bracket.
+
+The four properties that make the term trustworthy: it cycles the rotation
+the way a real series does, it is a no-op when no rotation is supplied, an
+ace actually helps and helps most in the game he starts, and two identical
+clubs stay a coin flip.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.sim.bracket import (
+    DEFAULT_ROTATION_SIZE, Rotations, play_postseason, play_series,
+    series_game_probs, strength_with_starter,
+)
+from src.sim.strength import home_win_prob
+
+LG_RA9 = 4.5          # a plausible league runs-allowed per nine
+
+
+def rotation(*deltas: float, first_id: int = 100) -> list[tuple[int, float]]:
+    """`[(pitcher_id, ra9_delta), ...]` with ids that are easy to eyeball."""
+    return [(first_id + i, d) for i, d in enumerate(deltas)]
+
+
+def rotations(by_team: dict[int, list[tuple[int, float]]]) -> Rotations:
+    return Rotations(by_team=by_team, lg_ra9=LG_RA9)
+
+
+def series_win_rate(high: int, low: int, wins_needed: int, strength, hfa,
+                    rots: Rotations | None, n: int = 20_000,
+                    seed: int = 7) -> float:
+    """Share of `n` simulated series the higher seed wins."""
+    rng = np.random.default_rng(seed)
+    wins = sum(play_series(high, low, wins_needed, strength, hfa, rng, rots) == high
+               for _ in range(n))
+    return wins / n
+
+
+class TestRotationCycling:
+    def test_four_man_rotation_repeats_in_game_five(self):
+        rots = rotations({0: rotation(-1.0, -0.5, 0.0, 0.5)})
+        assert len(rots.by_team[0]) == DEFAULT_ROTATION_SIZE
+        for game_idx in range(4):
+            assert rots.starter(0, game_idx) == rots.starter(0, game_idx + 4)
+        assert rots.starter(0, 0)[0] == 100      # game 1 is the first listed
+        assert rots.starter(0, 4)[0] == 100      # game 5 is the same arm
+        assert rots.starter(0, 1)[0] == 101
+
+    def test_the_probability_table_repeats_with_the_rotation(self):
+        """Game 5 of a best-of-7 is priced exactly like game 1."""
+        strength = np.array([0.55, 0.50])
+        rots = rotations({0: rotation(-1.0, 0.0, 0.0, 0.0),
+                          1: rotation(0.0, 0.0, 0.0, 0.0)})
+        at_home, _ = series_game_probs(0, 1, 4, strength, 0.54, rots)
+        assert len(at_home) == 7
+        assert at_home[4] == pytest.approx(at_home[0])
+        assert at_home[5] == pytest.approx(at_home[1])
+        assert at_home[0] > at_home[1]           # the ace game is the better one
+
+    def test_a_short_rotation_wraps_on_its_own_length(self):
+        """A three-man rotation repeats every three games, not every four."""
+        rots = rotations({0: rotation(-1.0, 0.0, 0.5)})
+        assert rots.starter(0, 3) == rots.starter(0, 0)
+        assert rots.starter(0, 4) == rots.starter(0, 1)
+
+
+class TestFallback:
+    def test_no_rotations_reproduces_the_seeded_result_exactly(self):
+        strength = np.array([0.58, 0.47, 0.52, 0.50])
+        for wins_needed in (2, 3, 4):
+            a = series_win_rate(0, 1, wins_needed, strength, 0.54, None, n=2000)
+            b = series_win_rate(0, 1, wins_needed, strength, 0.54,
+                                rotations({}), n=2000)
+            assert a == b
+
+    def test_a_team_without_a_rotation_keeps_team_strength(self):
+        """Only the side that has a rotation moves; the other is untouched."""
+        strength = np.array([0.55, 0.50])
+        flat = series_game_probs(0, 1, 4, strength, 0.54, None)[0][0]
+        # Team 1 has a league-average rotation, team 0 none at all.
+        rots = rotations({1: rotation(0.0, 0.0, 0.0, 0.0)})
+        at_home, _ = series_game_probs(0, 1, 4, strength, 0.54, rots)
+        assert at_home == pytest.approx(np.full(7, flat))
+
+    def test_a_zero_delta_rotation_is_a_no_op(self):
+        """The Pythagenpat inversion round-trips, so league-average is identity."""
+        for p in (0.42, 0.5, 0.61):
+            assert strength_with_starter(p, 0.0, 2 * LG_RA9) == p
+
+    def test_postseason_falls_back_per_series(self):
+        strength = np.full(12, 0.5)
+        seeds = {103: [0, 1, 2, 3, 4, 5], 104: [6, 7, 8, 9, 10, 11]}
+        plain = play_postseason(seeds, np.full(12, 90), strength, 0.54,
+                                np.random.default_rng(0))
+        empty = play_postseason(seeds, np.full(12, 90), strength, 0.54,
+                                np.random.default_rng(0), rotations({}))
+        assert plain.champion == empty.champion
+        assert plain.pennant == empty.pennant
+
+
+class TestAceEffect:
+    """A pitcher a full run per nine better than league is worth real games."""
+
+    ACE = -1.0
+
+    def test_the_ace_lifts_game_one_above_game_two(self):
+        strength = np.array([0.50, 0.50])
+        rots = rotations({0: rotation(self.ACE, 0.0, 0.0, 0.0),
+                          1: rotation(0.0, 0.0, 0.0, 0.0)})
+        at_home, on_road = series_game_probs(0, 1, 4, strength, 0.54, rots)
+        assert at_home[0] > at_home[1]
+        assert on_road[0] > on_road[1]
+        # And game 2, with both sides league average, is the untouched price.
+        flat_home = home_win_prob(0.50, 0.50, 0.54)
+        assert at_home[1] == pytest.approx(flat_home)
+
+    def test_the_ace_beats_a_flat_rotation_over_a_series(self):
+        strength = np.array([0.50, 0.50])
+        flat = rotations({0: rotation(0.0, 0.0, 0.0, 0.0),
+                          1: rotation(0.0, 0.0, 0.0, 0.0)})
+        with_ace = rotations({0: rotation(self.ACE, 0.0, 0.0, 0.0),
+                              1: rotation(0.0, 0.0, 0.0, 0.0)})
+        p_flat = series_win_rate(0, 1, 4, strength, 0.54, flat)
+        p_ace = series_win_rate(0, 1, 4, strength, 0.54, with_ace)
+        # The ace starts two of at most seven games; a one-run-per-nine edge
+        # over 5.5 innings is worth a few points of series probability, which
+        # is far outside the ±0.7 pt standard error of 20,000 series.
+        assert p_ace > p_flat + 0.01
+
+    def test_the_effect_is_monotone_in_the_delta(self):
+        strength = np.array([0.50, 0.50])
+        probs = [series_game_probs(
+            0, 1, 4, strength, 0.54,
+            rotations({0: rotation(d, 0.0, 0.0, 0.0)}))[0][0]
+            for d in (0.75, 0.0, -0.75, -1.5)]
+        assert probs == sorted(probs)
+
+
+class TestSymmetry:
+    def test_identical_teams_and_rotations_are_a_coin_flip(self):
+        """HFA off (0.5), so the only asymmetry left would be a bug."""
+        strength = np.array([0.5, 0.5])
+        rot = rotation(-1.0, -0.3, 0.2, 0.6)
+        rots = rotations({0: list(rot), 1: [(200 + i, d) for i, (_, d) in enumerate(rot)]})
+        for wins_needed in (2, 3, 4):
+            p = series_win_rate(0, 1, wins_needed, strength, 0.5, rots)
+            # 20,000 series → standard error 0.0035; 4 SE is a generous band.
+            assert p == pytest.approx(0.5, abs=0.015)
+
+    def test_a_matchup_table_is_symmetric_under_swapping_the_sides(self):
+        strength = np.array([0.54, 0.48])
+        a = rotation(-0.8, 0.1, 0.3, 0.0)
+        b = [(300 + i, d) for i, d in enumerate((-0.2, -0.6, 0.4, 0.1))]
+        at_home, _ = series_game_probs(0, 1, 4, strength, 0.54,
+                                       rotations({0: a, 1: b}))
+        _, on_road = series_game_probs(1, 0, 4, strength, 0.54,
+                                       rotations({0: a, 1: b}))
+        # `on_road` from the mirrored call is P(1 wins visiting game k), which
+        # is the complement of P(0 wins hosting it).
+        assert at_home == pytest.approx(1.0 - on_road)
+
+
+class TestRunEnvironment:
+    def test_a_bigger_run_environment_damps_the_same_delta(self):
+        """A run per nine is a smaller share of a high-scoring game."""
+        low_env = strength_with_starter(0.5, -1.0, 2 * 3.5)
+        high_env = strength_with_starter(0.5, -1.0, 2 * 5.5)
+        assert low_env > high_env > 0.5
+
+    def test_per_team_run_env_is_used_when_supplied(self):
+        strength = np.array([0.5, 0.5])
+        env = np.array([2 * 3.5, 2 * 3.5])
+        default = Rotations({0: rotation(-1.0)}, lg_ra9=5.5)
+        with_env = Rotations({0: rotation(-1.0)}, lg_ra9=5.5, run_env=env)
+        a = series_game_probs(0, 1, 4, strength, 0.54, default)[0][0]
+        b = series_game_probs(0, 1, 4, strength, 0.54, with_env)[0][0]
+        assert b > a
+
+
+class TestOddsIntegration:
+    def test_run_playoff_odds_threads_rotations_into_the_bracket(self):
+        """A league-wide ace for one club must lift its P(WS), same seed."""
+        import pandas as pd
+
+        from src.sim.odds import run_playoff_odds
+        from src.sim.season import from_schedule
+
+        teams = pd.DataFrame({
+            "team_id": range(1, 13),
+            "abbrev": [f"T{i}" for i in range(1, 13)],
+            "name": [f"Team {i}" for i in range(1, 13)],
+            "league_id": [103] * 6 + [104] * 6,
+            "division_id": [200, 200, 201, 201, 202, 202,
+                            203, 203, 204, 204, 205, 205],
+        })
+        rows = []
+        for i, home in enumerate(range(1, 13)):
+            away = 1 + (home % 12)
+            rows.append({"game_pk": 9000 + i, "date": "2026-09-20",
+                         "game_datetime": "", "status": "Preview",
+                         "game_type": "R", "home_id": home, "away_id": away,
+                         "home_score": None, "away_score": None})
+        state = from_schedule(pd.DataFrame(rows), teams)
+        strength = pd.Series({t: 0.5 for t in range(1, 13)})
+
+        plain = run_playoff_odds(state, strength, 0.54, n_sims=400, seed=11)
+        rots = Rotations({0: rotation(-2.0, -2.0, -2.0, -2.0)}, lg_ra9=LG_RA9)
+        laden = run_playoff_odds(state, strength, 0.54, n_sims=400, seed=11,
+                                 rotations=rots)
+        p = lambda df: float(df.set_index("abbrev").loc["T1", "p_ws"])  # noqa: E731
+        assert p(laden) > p(plain)


### PR DESCRIPTION
BAS-42 / closes #25. Follows #22: the regular season already uses the starter term; the bracket still priced every series game on team strength. Implemented by an Opus subagent in an isolated worktree; the validation run was reproduced in this session (max |Δ P(pennant)| 4.68 pts, CHC).

## What changes

`play_series` / `play_postseason` accept optional per-team **rotations** (ordered `(pitcher_id, RA/9 delta from league)`, ace first). Game 1 uses the first arm, wrapping on the rotation's own length, so a 4-man rotation repeats in game 5. A matchup collapses to two short per-game probability vectors (hosting / visiting), memoized per matchup, so `play_series` only draws uniforms in game order and the seed → result property holds. The bracket receives talent win%, so `strength_with_starter` inverts Pythagenpat at the club's run environment, moves runs allowed by `5.5/9 · delta` (the same delta form and weighting as the regular-season term), and converts back; the inversion is exact, so a zero delta is a bitwise no-op, which is what makes the fallback per team rather than per matchup.

`run_playoff_odds.py` builds **one** rate table for both terms. Rotations = the six pitchers with the most starts for the club, ranked by regressed FIP, best four kept. `--rotation-size` (default 4), `--rotation-compare`; `--no-starters` disables both terms.

## Validation (5,000 sims, seed 245, overrides held fixed)

| Team | Δ P(pennant) | Δ P(WS) | Game 1 / Δ RA/9 | Game 2 / Δ RA/9 |
|---|---|---|---|---|
| CHC | −4.68 | −2.94 | Imanaga −0.08 | Boyd −0.04 |
| CWS | −4.58 | −2.94 | Hudson −0.13 | Burke −0.03 |
| MIL | +2.98 | +3.98 | Misiorowski −1.15 | Henderson −0.70 |
| TB | +2.90 | +0.58 | Jax −0.76 | Rasmussen −0.54 |
| NYY | +2.20 | +0.94 | Schlittler −0.74 | Fried −0.49 |

**This term clears the simulator's noise floor** (seed-to-seed spread 1.0–2.2 pts on pennant, 0.6–1.5 on WS), and the on/off comparison replicates at seed 246 naming the same five clubs the same way. Playoff odds themselves move ≤ 0.02 pts, as they should: this only touches the bracket.

## Kalshi

No `KXMLBSERIES` markets exist yet in any status — individual series list once matchups are set, so the comparison this term really wants waits for October. Against the open season-long futures (`KXMLB` / `KXMLBAL` / `KXMLBNL`, 1–2¢ spreads) rotations move us slightly toward the market on pennant (top-10 mean abs gap 5.70 → 5.14 pts) and slightly away on WS (3.91 → 4.01); both are dwarfed by the LAD (−12) / MIL (+12 to +17) gaps team strength already owns. Reads as "no contradiction", not evidence either way. Recorded in `docs/playoff-odds-validation.md`.

## Tests

15 new in `tests/test_sim/test_bracket_starters.py`: cycling, fallback (None ≡ empty ≡ pre-change; zero delta bitwise identity; per-team fallback), ace effect (g1 > g2, ace beats a flat rotation, monotone in delta), symmetry at HFA 0.5 for all series lengths, end-to-end. Suite 310.

## Caveats (documented)

Six-by-starts then four-by-FIP can hand game 1 to a swingman (CWS leads with a 7-start arm); openers count as starts; order is FIP's, not the manager's (NYY lines Schlittler ahead of Cole); mid-season trades split a pitcher across clubs; health, eligibility and clinch-and-rest are invisible. One correction to the ticket text: `play_series` was never vectorized across sims (nor at `origin/main`); the precomputation is a per-matchup table, which is where the cost was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_