### PR TITLE
BAS-70: spend the posterior on props — beta-binomial pricing, selection on P(edge > 0), and a Kelly correction

### DIFF
--- a/docs/bayes-components.md
+++ b/docs/bayes-components.md
@@ -1,0 +1,35 @@
+# Rolling the K% pattern to BB% and HR/PA
+
+Tracked as BAS-73. Follow-on from [bayes-variants.md](bayes-variants.md).
+
+**Status: pre-registered, not yet run.**
+
+The hierarchical model exists for one of five hitting components. BB/PA and
+HR/PA are per-plate-appearance binomials exactly like K/PA — same cell
+structure, same likelihood, a different numerator column and a different
+league-level prior — so they are the two that roll out with no new design.
+ISO (per AB, not binomial) and BABIP (per ball in play) need their own
+denominators and come after.
+
+## Pre-registered predictions
+
+Measured on the dense harness (biweekly cutoffs, 2022/2024/2025/2026),
+`bayes_walk` against `marcel_tuned`, clustered by player.
+
+1. **BB%: a draw, like K%.** Remaining deficit ≤ +0.0005, \|t\| < 2. Walks
+   are a stable, high-count skill; there is nothing for pooling to add that
+   a tuned ballast does not.
+2. **HR/PA: the walk beats tuned Marcel.** Δ MAE < 0, clustered t < −2. Home
+   runs are the rare event — a .03 rate on a few hundred trials — and rare
+   events are where partial pooling earns more than a fixed ballast, because
+   the right amount of shrinkage varies with the player's exposure in a way
+   one constant cannot track. This is the first component where the
+   hierarchical arm is predicted to *win*, not draw.
+3. `sigma_step` is **smaller for BB% than for K%** (walks drift less) and
+   **larger for HR/PA** (power changes faster and is noisier), on the logit
+   scale.
+
+### Vacuity check
+
+If either component's `sigma_step` posterior mean is below 0.02, the walk
+collapsed for that component and prediction 1/2 is untestable for it.

--- a/docs/modelling-roadmap.md
+++ b/docs/modelling-roadmap.md
@@ -212,7 +212,7 @@ Three consumers, verified in the code:
 | Consumer | What it gets now | Why that is wrong |
 |---|---|---|
 | `src/market/props.py` | Poisson on a **point estimate** of a rate | Its own docstring admits the Poisson understates the tail. Rate uncertainty is discarded on top of that, so prop prices are overconfident in a way no rate accuracy fixes. |
-| `src/market/pnl.py` | `kelly_stake(p_win, ...)` — a **scalar** | Kelly under parameter uncertainty is provably not Kelly at the mean; the correct stake shades down. We are systematically overbetting by an amount nobody has measured. |
+| `src/market/pnl.py` | `kelly_stake(p_win, ...)` — a **scalar** | ~~Kelly under parameter uncertainty is provably not Kelly at the mean; the correct stake shades down.~~ **Retracted** ([posterior-props.md](posterior-props.md)): for a one-shot binary contract expected log growth is linear in `p`, so the posterior-optimal stake *is* Kelly at the posterior mean — checked to 1e-4 and pinned by `tests/test_market/test_posterior_kelly.py`. What feels like overbetting on a prop is selection on a noisy edge, which the stake cannot fix. |
 | `src/sim/season.py` | `simulate_remaining(state, strength: pd.Series, ...)` — **one number per team** | The Monte Carlo samples game outcomes but not parameter uncertainty. Every published playoff probability is conditional on the point estimate being exactly right. |
 
 The third **has now been built and scored, and it failed.** It is left in the
@@ -245,6 +245,15 @@ matter.
 The first two are where money is the exam. If a posterior changes P&L, that is
 the strongest possible evidence for the Bayesian track — far stronger than a
 component MAE tie.
+
+**Both have now been tested ([posterior-props.md](posterior-props.md)).** The
+beta-binomial price is better by 0.00003 of Brier at t = −6 — real, and
+worth nothing. Selecting on `P(edge > 0)` reproduces a 0.4-point threshold
+rule to within 0.2 points of ROI, because Marcel's sampling uncertainty is
+nearly the same for every regular and so cannot reorder bets. The posterior
+that could is the hierarchical model's — drift and population uncertainty
+vary by player — and that is the next test, once BAS-73 gives it more than
+one component to price with.
 
 **Sequence:** posterior into the simulator (testable against a known anomaly) →
 posterior into Kelly sizing (measurable in the money exam) → posterior into prop

--- a/docs/pitching-stuff.md
+++ b/docs/pitching-stuff.md
@@ -1,0 +1,96 @@
+# Pitching layer 1: a "stuff" model from public pitch tracking
+
+Tracked as BAS-71. Closes the gap [target-system.md](target-system.md) marks
+**NOT STARTED** for pitching at layer 1, and is the first item in
+[modelling-roadmap.md §2](modelling-roadmap.md#2-new-information--where-ml-has-something-to-chew-on)
+("pitch characteristics → run value ... completely untouched").
+
+**Status: pre-registered, not yet run.** Predictions written into the commit
+that added this file, before any model was fitted. Results get appended,
+including the ones that go against the predictions.
+
+## Why this is the next layer-1 piece
+
+What front offices do that we do not is mostly **measurement**: models that
+read the pitch itself — velocity, movement, release, spin — and score it,
+so the talent layer pools a measured skill instead of a noisy strikeout
+count. That is the two-stage pattern of
+[methods.md §3](methods.md#3-the-two-stage-pattern), and it has cleared the
+gate once already on the hitting side: six Statcast contact aggregates beat
+`marcel_tuned` on nine of ten components
+([contact-quality.md](contact-quality.md)). Pitching has nothing at layer 1.
+Public Statcast carries per-pitch `release_speed`, `pfx_x`/`pfx_z`,
+`release_pos_x/y/z`, `release_extension`, `release_spin_rate`, `spin_axis`,
+`arm_angle`, `vx0…az`, `plate_x/z` and the pitch outcome for every pitch since
+2015 — 1.4 GB in R2, twelve seasons. This is the richest thing we own that no
+model has read.
+
+## What gets built
+
+Exactly the contact-quality shape, so the harness, the gate and the honesty
+checks are all reused rather than reinvented.
+
+**Stage 1 — the measurement model.** A gradient-boosted classifier, walk-
+forward by season (fit on pitches from seasons ≤ Y−1, score season Y), from
+pitch characteristics to the pitch's outcome:
+
+- **target A: whiff** — swinging strike given a swing;
+- **target B: CSW** — called strike or whiff, given the pitch;
+
+from `release_speed`, `pfx_x`, `pfx_z`, `release_pos_x`, `release_pos_z`,
+`release_extension`, `release_spin_rate`, `spin_axis`, `arm_angle`, the
+velocity/acceleration vector, pitcher handedness, and the pitch's velocity
+and movement *relative to the same pitcher's fastball* (the thing "stuff"
+models actually key on). **Location is deliberately excluded** — that is the
+definition of stuff as opposed to pitching — and a second variant with
+`plate_x/z` added is fitted as a labelled comparison, never merged in.
+
+**Stage 1 controls, fitted the same way:** a pitch-type-only model and a
+fastball-velocity-only model. A stuff model that cannot beat "what pitch was
+it and how hard" out of sample has not measured anything.
+
+**Reduction.** Per pitcher, per calendar month: pitch count, mean predicted
+whiff and CSW, the same for fastballs and for non-fastballs, mean velocity,
+and the pitch-type mix — committed as
+`data/features/pitching_stuff_monthly.parquet`, additive buckets so any
+first-of-month cutoff is reconstructed by summing strictly-earlier months
+with no leak, exactly as `contact_quality_monthly.parquet` is.
+
+**Stage 2 — the gate.** The monthly aggregates as covariates on
+`marcel_pitcher_tuned`, scored walk-forward on the five pitcher cells of
+`scripts/run_pitcher_backtest.py` against the live baseline, paired per
+pitcher, standard error clustered by pitcher, on the common set.
+
+## Pre-registered predictions
+
+1. **Stage 1 beats both controls out of sample** on every scored season:
+   log-loss on whiff-given-swing lower than pitch-type-only and velocity-only
+   by at least 0.01. If it does not, stuff is fastball velocity by another
+   name and stage 2 is not worth running.
+2. **The stuff aggregate clears the gate on pitcher K/BF** — the component
+   most directly downstream of whiffs — by **2% to 6% of MAE** against
+   `marcel_pitcher_tuned`, clustered \|t\| > 2.5. Reasoning: contact quality
+   gave 1.6–4.8% on the hitting side from a coarser measurement.
+3. **It is information, not denoising.** Split as contact-quality §6 did:
+   the gain does **not** evaporate for high-exposure pitchers or by the
+   August cutoff. A pitcher who added velocity or a new pitch is measurably
+   different before his strikeout rate catches up, which is the whole reason
+   teams build these. If the gain lives only in low-exposure pitchers, this
+   prediction fails and the model is a variance reducer.
+4. **HR/BF and BB+HBP/BF move less** — under 2% — because stuff is about
+   contact avoidance, and a pitch's movement says more about a whiff than
+   about a walk.
+
+### Vacuity check
+
+If the walk-forward stage-1 model's out-of-sample AUC on whiff-given-swing
+is below **0.62**, the public tracking fields do not separate pitches well
+enough for any downstream test to mean anything; report it and stop.
+
+### Failure conditions
+
+- Prediction 2 fails but 1 holds: the measurement is real but K/BF already
+  captures it — stuff would then belong at layer 3/5 (usage, matchup) rather
+  than as a talent covariate.
+- Prediction 3 fails: publish it as denoising, keep the covariate if it
+  clears the gate, and do not describe it as measuring skill.

--- a/docs/posterior-props.md
+++ b/docs/posterior-props.md
@@ -1,0 +1,145 @@
+# Spending the posterior on player props
+
+Tracked as BAS-70. Follow-on from [bayes-variants.md](bayes-variants.md).
+
+**Status: pre-registered, not yet run.** Predictions below were written into
+the commit that added them, before any arm was priced. Results get appended,
+including the ones that go against the predictions.
+
+## Why this, and why now
+
+BAS-69 left the hierarchical K% arm level with tuned Marcel on point accuracy.
+There is no obvious accuracy left to win at layer 2, and the asset the
+Bayesian track has that Marcel structurally cannot offer — a distribution
+rather than a number — has never been spent on anything.
+[modelling-roadmap.md §1](modelling-roadmap.md#1-the-posterior--things-that-need-a-distribution-and-are-handed-a-number)
+names three consumers that are handed a number and need a distribution. The
+simulator was tested first and it failed — there was no over-confidence to
+fix. The two that remain are where money is the exam: prop pricing and stake
+sizing.
+
+## A correction before anything is built
+
+The roadmap says:
+
+> Kelly under parameter uncertainty is provably not Kelly at the mean; the
+> correct stake shades down. We are systematically overbetting by an amount
+> nobody has measured.
+
+**For a one-shot binary contract this is false.** A contract bought at cost
+`c` pays 1, so with stake fraction `f` and true win probability `p`,
+
+    E[log W] = p · log(1 + f·(1−c)/c) + (1 − p) · log(1 − f)
+
+which is **linear in p**. Taking the expectation over any posterior `q(p)` —
+however wide — gives the same expression evaluated at `E_q[p]`. So the stake
+that maximises expected log growth under the posterior is exactly Kelly at
+the posterior mean. Checked numerically before this was written: for Beta
+posteriors with mean 0.60 and standard deviations from 0.015 to 0.148, the
+posterior-optimal fraction and the plug-in fraction agree to five decimals
+(`tests/test_market/test_posterior_kelly.py` pins this).
+
+Where "shade down under uncertainty" *is* right is a different problem —
+repeated bets against one persistent unknown `p`, where the policy should
+learn, or a payoff nonlinear in `p`. Neither is a prop. What practitioners
+actually experience as "Kelly overbets" on a prop is **selection**: the bets
+we take are the ones where the estimated edge is large, and an estimate that
+is large is more likely to be large *because of* noise. That is a winner's
+curse on the edge, and no amount of shading the stake at the mean fixes it,
+because the mean is what is biased.
+
+So the posterior is not for the stake. It is for two other things.
+
+## What gets built
+
+The hitter rates behind every prop are Marcel-with-the-partial-season
+(`src/sim/lineups.marcel_rates`): weighted successes plus a ballast times the
+league rate, over weighted trials plus the ballast. That *is* the mean of a
+Beta posterior with pseudo-counts
+
+    Beta( num_w + ballast·lg ,  (den_w − num_w) + ballast·(1 − lg) )
+
+so the distribution has been sitting inside the estimator all along, and
+[methods.md §6](methods.md#6-techniques-worth-reusing-and-where-they-came-from)
+already derives the correspondence. Nothing new has to be fitted; the pseudo-
+counts have to be exposed instead of collapsed.
+
+**Why Marcel's Beta and not the hierarchical model's posterior.** The K% model
+is one component of five. A hits, HR or total-bases prop needs all five, and
+the other four do not exist yet at the plate-appearance level. The consumer
+built here takes posterior draws per component, and it does not care where
+they came from — the day the remaining components exist, the same pricing and
+selection code takes their draws. What Marcel's Beta *misses* is named rather
+than hidden: it carries sampling uncertainty in the estimate and nothing else,
+so it has no between-season drift (`sigma_step`, which BAS-69 measured at
+0.13 on the logit) and no population uncertainty. It is a lower bound on how
+wide the posterior should be.
+
+### 1. Beta-binomial pricing
+
+Today `P(over)` is a Binomial on a point rate. With the rate itself drawn from
+the Beta above, `P(over)` is the **marginal** over the rate — a beta-binomial
+on hits and home runs, and a rate-mixture on total bases. That is a genuinely
+different number, because `P(count ≥ line)` is convex in the rate at the
+lines that matter: a hitter at 2+ HR or 3+ hits is priced too low by a point
+estimate, and the gap grows as the rate is less certain (a rookie, a
+part-timer, April). `props.py`'s own docstring says its Poisson understates
+the tail; this is the tail it understates.
+
+### 2. Selection on the probability the edge is real
+
+Today a bet is taken when `|p_model − price| > 2 pts`. With a distribution
+over `p_model`, take it when **`P(edge > 0) > τ`** — the posterior probability
+that our side is the right side. A 3-point edge on a rate the Beta pins to
+±1 point and a 3-point edge on a rate it puts at ±6 points are the same bet
+to the current rule and very different bets to this one. `τ` is chosen
+walk-forward on the first half of the archive by date and scored on the
+second, exactly as the matchup weight was.
+
+### Not built, deliberately
+
+**Posterior Kelly.** See the correction above. It would be plug-in Kelly with
+extra steps, and building it would suggest the roadmap's claim survived.
+
+## Pre-registered predictions
+
+The measurement is `scripts/props_exam.py` on the committed archive
+(`data/market/prop_closes_2026.parquet`, 2026-07-31 → 09-02, ~62k settled
+contracts), Brier paired per contract with the standard error clustered by
+game, money at edge ≥ 2 pts on Kalshi as quoted and with the fee waived.
+
+1. **Beta-binomial pricing improves Brier**, paired per contract against the
+   current point price, and the improvement is **concentrated at the
+   low-probability lines** (over rate below .15: 2+ HR, 3+ hits, 4+ TB) where
+   the point price is farthest below the marginal. Pooled effect small —
+   between 0.0002 and 0.0010 of Brier — with clustered \|t\| > 2. Reasoning:
+   the mixture only moves prices where the tail is fat and the rate is
+   uncertain, which is a minority of contracts.
+2. **Selecting on `P(edge > 0)` at the walk-forward τ beats selecting on
+   \|edge\| > 2 pts at a matched number of bets**, on the second half, on
+   ROI with the fee waived. Predicted size: 1 to 3 points of ROI. Reasoning:
+   the current rule's losses are the bets where a large mean edge sat on a
+   wide posterior; this rule declines exactly those.
+3. **Neither turns the props strategy profitable after the Kalshi taker
+   fee.** The fee was 5.1 of the 5.7 points lost, and nothing here touches
+   the fee. If prediction 2 holds, the fee-waived line moves from −0.6% toward
+   +1 to +2%; the as-quoted line stays negative.
+
+### Vacuity check, run before reading any of the above
+
+If the posterior standard deviation of `P(over)` has median below **0.005**
+across priced contracts, the Beta is too tight for either prediction to be
+testable — the rates are so well-determined that marginalising over them is
+a rounding error. That is itself a finding: it would say Marcel's ballast
+leaves too little uncertainty for a posterior to be worth anything, and the
+hierarchical model's wider posterior (drift, population) is the one to test.
+
+### Failure conditions
+
+- **Prediction 1 fails with the sign reversed** — beta-binomial prices are
+  *worse* at the tail. Then the point price was already too fat, the Poisson
+  docstring was wrong about the direction, and the fix is the opposite one.
+- **Prediction 2 fails at matched bet count.** Then the edge's noise is not
+  what the Beta measures — the losses come from *model* error, not
+  *estimation* error, and a wider posterior (the hierarchical one) is the
+  next test, not a different selection rule.

--- a/docs/posterior-props.md
+++ b/docs/posterior-props.md
@@ -2,7 +2,7 @@
 
 Tracked as BAS-70. Follow-on from [bayes-variants.md](bayes-variants.md).
 
-**Status: pre-registered, not yet run.** Predictions below were written into
+**Status: complete. Scored below; two of three predictions fail.** Predictions below were written into
 the commit that added them, before any arm was priced. Results get appended,
 including the ones that go against the predictions.
 
@@ -143,3 +143,119 @@ hierarchical model's wider posterior (drift, population) is the one to test.
   what the Beta measures — the losses come from *model* error, not
   *estimation* error, and a wider posterior (the hierarchical one) is the
   next test, not a different selection rule.
+
+## Results
+
+`scripts/props_exam.py --matchup on --posterior`, the served configuration,
+on the committed archive: **61,738 settled contracts, 455 games,
+2026-07-31 → 09-02**. Brier paired per contract with the standard error
+clustered by game; money on the second half by date (30,423 contracts) with
+τ chosen on the first.
+
+### Vacuity check: passes
+
+Median posterior sd of `P(over)` is **0.0149** on the full archive (hits
+0.014, HR 0.017, TB 0.013, strikeouts 0.039), three times the 0.005 line;
+19% of contracts fall below it. So what follows are real results, not
+artifacts of a posterior too tight to matter.
+
+### Prediction 1: sign holds, size and location fail
+
+> Beta-binomial improves paired Brier by 0.0002–0.0010, clustered \|t\| > 2,
+> concentrated at lines with over-rate below .15.
+
+| | n | Brier(marginal) − Brier(point) | t (game) | mean price shift |
+| --- | --- | --- | --- | --- |
+| all | 61,738 | **−0.00003** | −6.16 | +0.00002 |
+| tail lines (< .15) | 26,492 | −0.00001 | −2.91 | **+0.00026** |
+| other lines | 35,246 | −0.00005 | −5.69 | −0.00015 |
+
+The marginal price is better, and it is better with a t of six — but by
+**0.00003 of Brier, an order of magnitude below the predicted range**, and the
+improvement is *larger off the tail than on it*. The convexity mechanism is
+real: at tail lines the marginal sits 0.00026 *above* the point price, as
+predicted, and the point price was indeed too thin there. It is just tiny.
+Off the tail the marginal sits below the point price, and that correction —
+the point price being slightly too *high* where the count distribution is
+concave in the rate — turns out to be worth more. Per stat the gain lives
+almost entirely in total bases (t −7.1) and strikeouts (t −3.7); hits and
+home runs are indistinguishable (t −1.6, −0.4).
+
+Scored as written: the direction survives, the magnitude and the
+localisation do not. A price that is better by 0.00003 is not a different
+price.
+
+### Prediction 2: fails
+
+> Selecting on `P(edge > 0)` beats the threshold rule by 1–3 points of
+> fee-waived ROI at a matched number of bets.
+
+| rule, second half | bets | ROI fee-waived | ROI as quoted |
+| --- | --- | --- | --- |
+| threshold @ 2 pts (current) | 16,756 | +0.7% (−2.8, +4.0) | −4.0% |
+| **posterior @ τ = 0.65** | 23,912 | **+2.5%** (−1.0, +6.2) | −2.7% |
+| threshold @ matched count (0.42 pts) | 23,912 | **+2.3%** (−1.2, +5.8) | −2.8% |
+
+Against the current rule the posterior rule looks like a 1.8-point gain.
+Against a threshold rule *forced to take the same number of bets*, the gain
+is **0.2 points**, inside any interval. The posterior rule at τ = 0.65 is,
+almost exactly, "bet whenever the mean edge exceeds 0.4 points" — the
+matched threshold that reproduces its bet count. The τ grid says the same
+thing from the other side: fee-waived ROI is flat within ±0.2 points from
+τ = 0.55 to 0.80 and only falls beyond, so there is no interior optimum,
+only a looser filter.
+
+Why: the vacuity check asked whether the Beta was *wide enough*, and it was.
+It did not ask whether the width **varies across contracts enough to
+reorder them**, and it does not. With `p_over_sd` sitting in a band of
+roughly 0.008–0.023 for three of four stats, `P(edge > 0)` is a monotone
+function of the mean edge to a very good approximation, and a monotone
+re-labelling of the same ranking selects the same bets. The one stat where
+the width does vary — strikeouts, whose Beta is the approximation flagged
+above — is also the one where every rule loses 10–15%.
+
+This is the failure condition the pre-registration named: *the edge's noise
+is not what the Beta measures*. Marcel's sampling uncertainty is nearly the
+same for every regular, so it cannot tell a real 3-point edge from a
+spurious one. Whatever separates them is model error, and a wider, more
+player-specific posterior — the hierarchical model's, with its drift term
+and population uncertainty — is the next thing to test here, not a
+different selection rule on the same Beta.
+
+### Prediction 3: holds
+
+> Neither turns the props strategy profitable after the Kalshi taker fee.
+
+As quoted, every pooled rule is negative: −4.0%, −2.7%, −2.8%. The fee
+remains the whole loss.
+
+### Not pre-registered, and reported as such
+
+**Hits.** Every rule, both halves, fee-waived: +9.5% at the 2-point
+threshold, +12.1% under the posterior rule, +11.4% matched — intervals
+that exclude zero on the second half (+5.8% to +19.1% for the posterior
+rule). As quoted: +4.3% to +5.5%, intervals that do not exclude zero. A
+stat-level split of a pooled pre-registered test is exploratory, and the
+hits number was not predicted, so it is a lead and not a result. It is the
+first time anything on the props exam has been positive after the fee at
+the point estimate, and it is worth its own pre-registration on the June
+and July contracts the archive has not yet fetched.
+
+**Strikeouts** lose 10–16% under every rule, which is the same finding as
+the original props exam and is consistent with the pitcher-K Beta being an
+approximation stacked on a rate the market prices well.
+
+## What ships, and what does not
+
+Nothing. The marginal price is better by an amount that changes no decision;
+the posterior selection rule is a looser threshold wearing a distribution.
+`marcel_partial + matchup` at the 2-point threshold remains the props
+model, and it remains a model that loses after the fee.
+
+What the exercise bought is sharper than a shipped feature. The roadmap's
+Kelly claim is retracted by proof; the posterior's first consumer is
+scored and the reason it failed — width that does not vary — points
+directly at the next test; and the hits line is the first positive
+after-fee number on the board, flagged as exploratory so nobody quotes it
+as more.
+

--- a/docs/target-system.md
+++ b/docs/target-system.md
@@ -158,6 +158,37 @@ different construction, against a different baseline, from a per-fielder
 hierarchical spatial model. Do not cite it as evidence that defence is worthless
 to model.
 
+## 2c. The model inventory, component by component
+
+The three-track table above says where each *layer* stands. This one says
+where each *model* stands, so nothing falls between the layers. Every
+unstarted cell has a Linear issue; the status here is updated when one moves.
+
+**Hitting**
+
+| Component | L2 hierarchical model | L1 measurement feeding it |
+| --- | --- | --- |
+| K% (K/PA) | LIVE research arm: PA-level, season random walk, draws with `marcel_tuned` (BAS-69) | contact quality — gated, denoising (BAS-58); wiring: BAS-72 |
+| BB% (BB/PA) | NOT STARTED — BAS-73 | contact quality — gated; swing decisions — NOT STARTED, BAS-75 |
+| HR/PA | NOT STARTED — BAS-73 | contact quality — gated, *information* |
+| ISO (per AB) | recovered HSGP model, never scored in the harness (#86) — after BAS-73 | contact quality — gated, *information* |
+| BABIP (per BIP) | recovered HSGP model, never scored (#86) — after BAS-73 | contact quality — gated, denoising; sprint speed — NOT STARTED |
+
+**Pitching**
+
+| Component | L2 hierarchical model | L1 measurement feeding it |
+| --- | --- | --- |
+| K/BF | NOT STARTED — BAS-74 | stuff — IN FLIGHT, BAS-71 |
+| BB/BF, (BB+HBP)/BF | NOT STARTED — BAS-74 | command / location — NOT STARTED, BAS-76 |
+| HR/BF | NOT STARTED — BAS-74 | contact-quality-allowed — gated, *information*; stuff |
+| BABIP against | NOT STARTED — BAS-74 | contact-quality-allowed — gated |
+
+`marcel_tuned` / `marcel_pitcher_tuned` serve every component on both sides
+today and stay the baseline every model above must beat.
+
+**Defence** — framing cancelled; public pitch data carries no fielder
+tracking. This track stays thin until a public source exists.
+
 ## 3. So: are all the rates moving to Bayes?
 
 **Yes.** All five components, at layer 2, replacing Marcel as the engine.

--- a/scripts/props_exam.py
+++ b/scripts/props_exam.py
@@ -61,6 +61,14 @@ LABELS = {"model": "marcel_partial", "matchup": "marcel_partial + matchup",
 # How far the matchup term is allowed to pull, 1.0 being log5 exactly. Chosen
 # on the first half of the window; never on the half it is scored on.
 WEIGHT_GRID = (0.0, 0.25, 0.5, 0.75, 1.0)
+# The posterior-probability-of-edge threshold for decide_posterior. Chosen on
+# the first half by fee-waived flat-stake ROI, scored on the second — same
+# walk-forward discipline as WEIGHT_GRID. All values are >= 0.5, which is what
+# keeps decide_posterior from ever trading inside the spread (pnl.py).
+TAU_GRID = (0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90)
+# The column BAS-70's other half (src/market/props.py) is expected to add:
+# the posterior standard deviation of P(over) that decide_posterior needs.
+SD_COL = "p_over_sd"
 # How long before first pitch a club's own recent cards are pooled over when a
 # start's opposing card is not in the lineup archive.
 CARD_LOOKBACK_DAYS = 21
@@ -165,6 +173,153 @@ def halves_of(dates: list) -> tuple:
     """The first and second half of a window, split on the median date."""
     cut = dates[len(dates) // 2]
     return [d for d in dates if d < cut], [d for d in dates if d >= cut]
+
+
+# ─────────────────────── selecting on P(edge > 0) ───────────────────────
+
+def choose_tau(frame: pd.DataFrame, model: str, sd_col: str, cut: str,
+               venue: pnl.Venue, grid=TAU_GRID, date_col: str = "date") -> tuple:
+    """The tau that scores best on the **first half**, fee-waived flat-stake ROI.
+
+    Same discipline as `choose_weight`: a free parameter chosen on the data it
+    is scored on is not a result. `venue` should already be the fee-waived one
+    (`venue_for(0.0, frictionless=False)`) — fee-waived isolates the selection
+    rule's own quality from the fee, which is a separate, known loser (BAS-70
+    prediction 3). Ties, and a tau with zero bets, are broken toward the
+    smallest tau that has *any* bets, so a boundary solution (the grid's
+    least-selective end winning) is visible in the printed table rather than
+    silently landing on an empty cell.
+    """
+    train = frame[frame[date_col].astype(str) < cut]
+    rows = []
+    for tau in grid:
+        row = pnl.evaluate(train, model, venue, staking="flat",
+                           group_col="game_pk", rule="posterior", tau=tau,
+                           sd_col=sd_col)
+        rows.append({"tau": tau, "n_bets": row["n_bets"], "roi": row["roi"]})
+    table = pd.DataFrame(rows)
+    tradeable = table[table["n_bets"] > 0]
+    if tradeable.empty:
+        return float("nan"), table
+    best_roi = tradeable["roi"].max()
+    # Among ties on ROI (the coarse grid makes exact ties plausible at small
+    # n), the least-selective tau — most bets, closest to the threshold
+    # rule's own bet count — is the more conservative pick.
+    best = tradeable[tradeable["roi"] == best_roi].sort_values("n_bets",
+                                                                ascending=False)
+    return float(best.iloc[0]["tau"]), table
+
+
+def matched_threshold(frame: pd.DataFrame, model: str, venue: pnl.Venue,
+                      n_target: int, lo: float = 0.0, hi: float = 0.30,
+                      iters: int = 40) -> float:
+    """The `decide` threshold whose bet count on `frame` is closest to
+    `n_target`, found by bisection.
+
+    This is **not a chosen parameter** — it is a comparison device, found
+    after the fact on the same half the posterior rule is scored on, purely
+    so prediction 2 ("beats the threshold rule at a matched number of bets")
+    can actually be checked rather than confounded with "the posterior rule
+    just bets less." `decide`'s bet count is non-increasing in `threshold`
+    (a stricter margin never adds a bet), so bisection on that count is well
+    posed; ties on the count are resolved by keeping the candidate visited
+    first, which biases toward the tighter threshold — the harder standard
+    for the threshold rule to still be a fair comparator at.
+    """
+    def n_bets_at(t: float) -> int:
+        return len(pnl.bet_frame(frame, model, venue, threshold=t))
+
+    a, b = lo, hi
+    best_t, best_diff = lo, abs(n_bets_at(lo) - n_target)
+    for _ in range(iters):
+        mid = (a + b) / 2.0
+        n = n_bets_at(mid)
+        diff = abs(n - n_target)
+        if diff < best_diff:
+            best_t, best_diff = mid, diff
+        if n > n_target:
+            a = mid          # need a stricter margin to shed bets
+        elif n < n_target:
+            b = mid           # need a looser margin to gain bets
+        else:
+            best_t, best_diff = mid, 0
+            break
+    return best_t
+
+
+def posterior_comparison(frame: pd.DataFrame, model: str, sd_col: str, tau: float,
+                         threshold: float, venue_fee_waived: pnl.Venue,
+                         venue_as_quoted: pnl.Venue, draws: int, seed: int,
+                         group_col: str = "game_pk") -> pd.DataFrame:
+    """Threshold-at-2pt vs. posterior-at-tau vs. threshold-at-matched-count.
+
+    All three rows are evaluated on the same frame (the second, held-out half
+    of the window, whole or one prop stat), so the bet counts and ROIs are
+    directly comparable. `matched` is threshold-only — it exists to answer
+    "is the posterior rule just betting less?", not as a strategy of its own.
+    """
+    posterior_n = pnl.evaluate(frame, model, venue_as_quoted, staking="flat",
+                               group_col=group_col, rule="posterior", tau=tau,
+                               sd_col=sd_col)["n_bets"]
+    matched = matched_threshold(frame, model, venue_as_quoted, posterior_n)
+
+    specs = [
+        ("threshold @ 2pt", dict(rule="threshold", threshold=threshold)),
+        (f"posterior @ tau={tau:.2f}",
+         dict(rule="posterior", tau=tau, sd_col=sd_col)),
+        (f"threshold @ matched (t={matched:.4f})",
+         dict(rule="threshold", threshold=matched)),
+    ]
+    rows = []
+    for label, kwargs in specs:
+        fw = pnl.evaluate(frame, model, venue_fee_waived, staking="flat",
+                          group_col=group_col, draws=draws, seed=seed, **kwargs)
+        aq = pnl.evaluate(frame, model, venue_as_quoted, staking="flat",
+                          group_col=group_col, draws=draws, seed=seed, **kwargs)
+        rows.append({
+            "rule": label, "n_bets": fw["n_bets"],
+            "roi_fee_waived": fw["roi"], "roi_fee_waived_lo": fw["roi_lo"],
+            "roi_fee_waived_hi": fw["roi_hi"],
+            "roi_as_quoted": aq["roi"], "roi_as_quoted_lo": aq["roi_lo"],
+            "roi_as_quoted_hi": aq["roi_hi"],
+        })
+    return pd.DataFrame(rows)
+
+
+def posterior_comparison_by_stat(frame: pd.DataFrame, model: str, sd_col: str,
+                                 tau: float, threshold: float,
+                                 venue_fee_waived: pnl.Venue,
+                                 venue_as_quoted: pnl.Venue, draws: int,
+                                 seed: int, stat_col: str = "prop_stat") -> pd.DataFrame:
+    """`posterior_comparison`, pooled and broken out per prop stat.
+
+    The matched threshold is re-found **within each stat's own rows** — a
+    single pooled threshold would not give a matched *count* on a stat whose
+    posterior rule bet count differs from the pool's.
+    """
+    out = []
+    pooled = posterior_comparison(frame, model, sd_col, tau, threshold,
+                                  venue_fee_waived, venue_as_quoted, draws, seed)
+    pooled.insert(0, "stat", "all")
+    out.append(pooled)
+    for stat, grp in frame.groupby(stat_col):
+        t = posterior_comparison(grp.reset_index(drop=True), model, sd_col, tau,
+                                 threshold, venue_fee_waived, venue_as_quoted,
+                                 draws, seed)
+        t.insert(0, "stat", stat)
+        out.append(t)
+    return pd.concat(out, ignore_index=True)
+
+
+def posterior_comparison_markdown(table: pd.DataFrame) -> str:
+    out = ["| stat | rule | n bets | ROI fee-waived | 95% CI | ROI as-quoted | 95% CI |",
+           "|---|---|---|---|---|---|---|"]
+    for r in table.itertuples(index=False):
+        out.append(f"| {r.stat} | {r.rule} | {r.n_bets} | {pct(r.roi_fee_waived)} | "
+                   f"({pct(r.roi_fee_waived_lo)}, {pct(r.roi_fee_waived_hi)}) | "
+                   f"{pct(r.roi_as_quoted)} | "
+                   f"({pct(r.roi_as_quoted_lo)}, {pct(r.roi_as_quoted_hi)}) |")
+    return "\n".join(out)
 
 
 # ───────────────────────────── scoring ─────────────────────────────
@@ -414,6 +569,13 @@ def main() -> None:
                     help="write the priced frame to parquet for reuse")
     ap.add_argument("--priced-in", type=Path, default=None,
                     help="reuse a priced frame instead of rebuilding it")
+    ap.add_argument("--posterior", action="store_true",
+                    help="also run the P(edge>0) selection rule and the "
+                         "matched-bet-count comparison table (BAS-70); needs "
+                         f"a {SD_COL!r} column on the priced frame")
+    ap.add_argument("--tau", type=float, default=None,
+                    help="skip the walk-forward search and use this tau")
+    ap.add_argument("--tau-grid", nargs="+", type=float, default=list(TAU_GRID))
     args = ap.parse_args()
 
     closes_path = args.closes or default_closes()
@@ -482,6 +644,41 @@ def main() -> None:
         print(paired_halves(priced, "p_matchup", "p_market", cut).to_string(index=False))
     print("\n== money (taker) ==")
     print(grid.to_string(index=False))
+
+    posterior_table = None
+    if args.posterior:
+        primary = "matchup" if with_matchup else "model"
+        if SD_COL not in frame.columns:
+            logger.warning("--posterior requested but %r is not on the priced "
+                           "frame; skipping the P(edge>0) selection rule "
+                           "(this is the other half of BAS-70, built in "
+                           "src/market/props.py)", SD_COL)
+        else:
+            fee_waived = venue_for(0.0, args.frictionless)
+            as_quoted = venue
+            train = frame[frame["date"].astype(str) < cut]
+            second = frame[frame["date"].astype(str) >= cut]
+            if args.tau is not None:
+                tau, tau_table = args.tau, None
+            else:
+                tau, tau_table = choose_tau(train, primary, SD_COL, cut,
+                                            fee_waived, tuple(args.tau_grid))
+                logger.info("tau chosen on the first half: %.2f", tau)
+            print("\n== BAS-70: selecting on P(edge>0) ==")
+            if tau_table is not None:
+                print("\n-- tau grid, first half, fee-waived flat-stake ROI --")
+                print(tau_table.to_string(index=False))
+            print(f"chosen tau: {tau}")
+            posterior_table = posterior_comparison_by_stat(
+                second, primary, SD_COL, tau, args.headline, fee_waived,
+                as_quoted, args.draws, args.seed)
+            print("\n-- second half: threshold @ 2pt vs. posterior @ tau vs. "
+                  "threshold @ matched bet count (matched is a comparison "
+                  "device, not a chosen parameter) --")
+            print(posterior_table.to_string(index=False))
+            if args.markdown:
+                print("\n### BAS-70 selection comparison, second half\n")
+                print(posterior_comparison_markdown(posterior_table))
 
     maker = None
     if args.maker:

--- a/src/market/pnl.py
+++ b/src/market/pnl.py
@@ -72,6 +72,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
+from scipy.stats import norm
 
 KALSHI_TAKER_RATE = 0.07        # round_up_to_cent(0.07 · C · P · (1-P))
 KALSHI_MAKER_RATE = 0.0175      # a quarter of the taker rate; 0.44¢ max, at 50¢
@@ -168,6 +169,49 @@ def decide(p_model, bid, ask, threshold: float = 0.0) -> pd.DataFrame:
     return pd.DataFrame({"side": side, "cost": cost, "edge": taken})
 
 
+def decide_posterior(p_model, p_sd, bid, ask, tau: float) -> pd.DataFrame:
+    """Which side to take when the posterior *probability the edge is real*
+    clears `tau`, rather than when the *mean* edge clears a fixed margin.
+
+    `decide` treats a 3-point mean edge the same whether the estimate is
+    pinned to ±1 point or loose at ±6 — exactly the selection docs/
+    posterior-props.md's correction says the fee is really punishing:
+    an estimate large enough to clear the threshold is disproportionately
+    large *because of* noise, and thresholding the mean cannot tell a real
+    edge from a winner's-curse one. This rule can, by asking a different
+    question of the same estimate. Approximating the posterior on the true
+    probability as Normal(`p_model`, `p_sd`),
+
+        P(p_true > ask) = 1 − Φ((ask − p_model) / p_sd)   [``norm.sf``]
+        P(p_true < bid) = Φ((bid − p_model) / p_sd)       [``norm.cdf``]
+
+    and a side is taken when that posterior probability exceeds `tau`. A
+    contract with `p_sd = 0` has a point posterior, so both tail
+    probabilities collapse to 0/1 indicators and, for any `tau` strictly
+    between 0 and 1, this rule reduces exactly to `decide` at
+    `threshold=0`. For `tau >= 0.5` (the only region this repo's `TAU_GRID`
+    uses) a bet still requires `p_model` to be on the far side of the quote
+    it takes — `P(p_true > ask) > 0.5` iff `p_model > ask` — so, like
+    `decide`, this never trades inside the spread.
+    """
+    p = np.asarray(p_model, dtype=float)
+    sd = np.asarray(p_sd, dtype=float)
+    bid = np.asarray(bid, dtype=float)
+    ask = np.asarray(ask, dtype=float)
+    degenerate = ~(sd > 0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        p_above_ask = norm.sf((ask - p) / sd)
+        p_below_bid = norm.cdf((bid - p) / sd)
+    p_above_ask = np.where(degenerate, (p > ask).astype(float), p_above_ask)
+    p_below_bid = np.where(degenerate, (p < bid).astype(float), p_below_bid)
+    yes = p_above_ask > tau
+    no = p_below_bid > tau
+    side = np.where(yes, "yes", np.where(no, "no", NO_BET))
+    cost = np.where(yes, ask, np.where(no, 1.0 - bid, np.nan))
+    taken = np.where(yes, p - ask, np.where(no, bid - p, np.nan))
+    return pd.DataFrame({"side": side, "cost": cost, "edge": taken})
+
+
 # ───────────────────────────── stakes ─────────────────────────────
 
 def kelly_stake(p_win, cost, fraction: float = DEFAULT_KELLY_FRACTION,
@@ -178,6 +222,18 @@ def kelly_stake(p_win, cost, fraction: float = DEFAULT_KELLY_FRACTION,
     ``(p_win − cost) / (1 − cost)``. We take `fraction` of it and cap the
     result. Fees are not in the Kelly arithmetic — including them would shrink
     the stake, so leaving them out is the less flattering choice.
+
+    **This is also the right stake under a posterior, not just a point
+    estimate.** For a one-shot binary contract, expected log growth
+    ``p·log(1 + f(1−c)/c) + (1−p)·log(1−f)`` is linear in `p`, so its
+    expectation over any posterior `q(p)` — however wide — is the same
+    expression evaluated at `E_q[p]`. The stake that maximises
+    posterior-expected log growth is therefore exactly this function called
+    at the posterior mean; there is no separate "shade down under
+    uncertainty" correction to make for a prop. See
+    docs/posterior-props.md and `tests/test_market/test_posterior_kelly.py`,
+    which pins this numerically against a direct optimum over `f` for a
+    range of Beta posteriors.
     """
     p = np.asarray(p_win, dtype=float)
     c = np.asarray(cost, dtype=float)
@@ -355,10 +411,27 @@ def add_controls(df: pd.DataFrame, seed: int = 0,
 
 def bet_frame(df: pd.DataFrame, model: str, venue: Venue, threshold: float = 0.0,
               staking: str = "flat", fraction: float = DEFAULT_KELLY_FRACTION,
-              cap: float = DEFAULT_KELLY_CAP, bankroll: float = BANKROLL) -> pd.DataFrame:
-    """One row per bet actually placed, priced, staked and settled."""
+              cap: float = DEFAULT_KELLY_CAP, bankroll: float = BANKROLL,
+              rule: str = "threshold", tau: float | None = None,
+              sd_col: str | None = None) -> pd.DataFrame:
+    """One row per bet actually placed, priced, staked and settled.
+
+    `rule="threshold"` (the default, unchanged) is `decide` at `threshold`.
+    `rule="posterior"` is `decide_posterior` at `tau`, reading the per-row
+    posterior standard deviation from `df[sd_col]` — `threshold` is then
+    ignored. Every existing caller passes neither and gets exactly the old
+    behaviour.
+    """
     bid, ask = quotes(df, venue)
-    d = decide(df[model].to_numpy(dtype=float), bid, ask, threshold)
+    if rule == "threshold":
+        d = decide(df[model].to_numpy(dtype=float), bid, ask, threshold)
+    elif rule == "posterior":
+        if sd_col is None or tau is None:
+            raise ValueError("rule='posterior' needs both sd_col and tau")
+        p_sd = df[sd_col].to_numpy(dtype=float)
+        d = decide_posterior(df[model].to_numpy(dtype=float), p_sd, bid, ask, tau)
+    else:
+        raise ValueError(f"unknown rule {rule!r}")
     take = (d["side"] != NO_BET).to_numpy()
     if not take.any():
         return pd.DataFrame(columns=["date", "game_pk", "side", "cost", "edge",
@@ -384,11 +457,17 @@ def bet_frame(df: pd.DataFrame, model: str, venue: Venue, threshold: float = 0.0
 def evaluate(df: pd.DataFrame, model: str, venue: Venue, threshold: float = 0.0,
              staking: str = "flat", fraction: float = DEFAULT_KELLY_FRACTION,
              cap: float = DEFAULT_KELLY_CAP, draws: int = BOOTSTRAP_DRAWS,
-             seed: int = 0, group_col: str | None = None) -> dict:
-    """Metrics for one (model, venue, threshold, staking) cell."""
-    bets = bet_frame(df, model, venue, threshold, staking, fraction, cap)
+             seed: int = 0, group_col: str | None = None,
+             rule: str = "threshold", tau: float | None = None,
+             sd_col: str | None = None) -> dict:
+    """Metrics for one (model, venue, threshold, staking) cell.
+
+    `rule`/`tau`/`sd_col` pass straight through to `bet_frame`; see there.
+    """
+    bets = bet_frame(df, model, venue, threshold, staking, fraction, cap,
+                     rule=rule, tau=tau, sd_col=sd_col)
     row = {"venue": venue.name, "model": model, "threshold": threshold,
-           "staking": staking, "n_games": int(len(df))}
+           "staking": staking, "n_games": int(len(df)), "rule": rule, "tau": tau}
     row.update(summarize(bets, draws=draws, seed=seed, group_col=group_col))
     return row
 

--- a/src/market/props.py
+++ b/src/market/props.py
@@ -140,6 +140,40 @@ def threshold(line: float) -> int:
     return int(np.floor(float(line)) + 1)
 
 
+def _binom_at_least_vec(k: int, n: float, p) -> np.ndarray:
+    """`binom_at_least`, vectorised over an array of `p` — one call per draw.
+
+    Same fractional-`n` mixture as the scalar version, so a Monte Carlo mean
+    of this at one draw per weight is the same number `binom_at_least` would
+    give at that draw's `p`; the two prices stay comparable by construction.
+    """
+    p = np.clip(np.asarray(p, dtype=float), 0.0, 1.0)
+    if k <= 0:
+        return np.ones_like(p)
+    lo = int(np.floor(n))
+    w = float(n) - lo
+    out = np.zeros_like(p)
+    for trials, weight in ((lo, 1.0 - w), (lo + 1, w)):
+        if weight <= 0 or trials < 0 or k > trials:
+            continue
+        below = np.zeros_like(p)
+        for i in range(k):
+            below += comb(trials, i) * p ** i * (1.0 - p) ** (trials - i)
+        out += weight * (1.0 - below)
+    return np.clip(out, 0.0, 1.0)
+
+
+def _poisson_at_least_vec(k: int, mean) -> np.ndarray:
+    """`poisson_at_least`, vectorised over an array of means."""
+    m = np.clip(np.asarray(mean, dtype=float), 0.0, None)
+    if k <= 0:
+        return np.ones_like(m)
+    below = np.zeros_like(m)
+    for i in range(k):
+        below += np.exp(-m) * m ** i / factorial(i)
+    return np.clip(1.0 - below, 0.0, 1.0)
+
+
 # ───────────────────────────── the rate → prop step ─────────────────────────
 
 def pa_outcome_probs(rates, lg: dict) -> dict:
@@ -177,6 +211,97 @@ def pitcher_prop_prob(stat: str, line: float, rate_k: float,
     if stat != "k":
         raise ValueError(f"{stat} is not a pitcher prop this module prices")
     return binom_at_least(threshold(line), bf, rate_k)
+
+
+# ─────────────────── the marginal price (BAS-70, docs/posterior-props.md) ────
+#
+# `p_model` above is Binomial/Poisson on the *point* rate `lineups.marcel_rates`
+# returns. That rate is the mean of an explicit Beta posterior (the ballast
+# arithmetic already computes its pseudo-counts; `alpha_<c>`/`beta_<c>` just
+# expose them instead of collapsing them). `P(count >= line)` is convex in the
+# rate at the lines that matter, so the marginal over that Beta — `p_over_bb`
+# ("bb" for beta-binomial, the pricing this section adds) — is a genuinely
+# different, fatter-tailed number, and the gap is the thing docs/posterior-
+# props.md predicts and the vacuity check below measures.
+#
+# A hits or HR price is a function of all five component rates through
+# `event_rates`, not of one Beta, so there is no closed-form marginal here —
+# the honest construction is Monte Carlo: draw each of the five rates from its
+# own Beta *independently* (this is an approximation flagged once here rather
+# than at every call site: the components are not independent — a hitter's K%
+# and BABIP both move with the same plate appearances — and drawing them
+# independently overstates how much the joint spreads relative to a model that
+# knew the covariance; nothing in the estimator gives us that covariance to
+# draw from), push each draw through the same `event_rates` step the point
+# price uses, price each draw with the same binomial/Poisson machinery
+# (`_binom_at_least_vec` / `_poisson_at_least_vec` mirror the scalar fractional-
+# `n` interpolation exactly), and average. Total bases reuses the same draws —
+# it is a rate-mixture on the same five components, not a separate model.
+MC_DRAWS = 2000
+# Fixed so a rerun on the same inputs reproduces the same price and the same
+# measured Monte Carlo error; advances per (player, as-of-date) in the order
+# `price()` visits them, not reseeded per contract, so contracts sharing a
+# player+date (three lines on the same 1+/2+/3+ hits market) share draws
+# rather than independently resampling the same posterior.
+MC_SEED = 20260909
+
+
+def _component_draws(rates_row, rng: np.random.Generator,
+                     n: int = MC_DRAWS) -> pd.DataFrame:
+    """`n` draws of the five component rates from their per-component Betas."""
+    return pd.DataFrame({f"rate_{c}": rng.beta(float(rates_row[f"alpha_{c}"]),
+                                                float(rates_row[f"beta_{c}"]), size=n)
+                         for c in lu_model.COMPONENTS})
+
+
+def _per_pa_draws(draws: pd.DataFrame, lg: dict) -> dict:
+    """`_component_draws` output -> per-draw arrays of hit / HR / TB per PA.
+
+    Vectorised twin of `pa_outcome_probs`: `event_rates` already accepts a
+    DataFrame of rates and returns a DataFrame of event probabilities, so this
+    is the same arithmetic run once over `n` draws instead of once over a
+    point estimate.
+    """
+    ev = lu_model.event_rates(draws, lg)
+    ts = float(lg["triple_share"])
+    return {"hit": (ev["b1"] + ev["d23"] + ev["hr"]).to_numpy(),
+            "hr": ev["hr"].to_numpy(),
+            "tb": (ev["b1"] + (2.0 + ts) * ev["d23"] + 4.0 * ev["hr"]).to_numpy()}
+
+
+def _apply_matchup_draws(draws: pd.DataFrame, factors: dict, weight: float) -> pd.DataFrame:
+    """The matchup factor applied to every draw of every component.
+
+    `matchup.apply_factor` is already vectorised (`np.asarray` under the
+    hood), so this is `matchup.matchup_rates` run over an array of draws
+    instead of one point rate per component.
+    """
+    from src.market import matchup as mu
+    out = pd.DataFrame(index=draws.index)
+    for c in lu_model.COMPONENTS:
+        out[f"rate_{c}"] = mu.apply_factor(draws[f"rate_{c}"].to_numpy(),
+                                           factors.get(c, 1.0), weight)
+    return out
+
+
+def _batter_mc_price(stat: str, line: float, per_pa_draws: dict, pa: float) -> tuple:
+    """Mean and standard deviation of `P(over)` across the component draws."""
+    k = threshold(line)
+    if stat == "hits":
+        d = _binom_at_least_vec(k, pa, per_pa_draws["hit"])
+    elif stat == "hr":
+        d = _binom_at_least_vec(k, pa, per_pa_draws["hr"])
+    elif stat == "tb":
+        d = _poisson_at_least_vec(k, pa * per_pa_draws["tb"])
+    else:
+        raise ValueError(f"{stat} is not a batter prop this module prices")
+    return float(d.mean()), float(d.std(ddof=0))
+
+
+def _pitcher_mc_price(line: float, rate_draws, pa: float) -> tuple:
+    """Mean and standard deviation of `P(over)` across draws of `rate_k`."""
+    d = _binom_at_least_vec(threshold(line), pa, rate_draws)
+    return float(d.mean()), float(d.std(ddof=0))
 
 
 # ───────────────────────── as-of-date assembly ─────────────────────────
@@ -218,11 +343,39 @@ def batter_rates(inputs: dict, as_of: str, ballast=lu_model.BALLAST) -> pd.DataF
 
 def pitcher_rates(inputs: dict, as_of: str,
                   ballast=sp_model.BALLAST_BF) -> pd.DataFrame:
-    """The same, per batter faced, for pitchers."""
+    """The same, per batter faced, for pitchers — plus an approximate Beta.
+
+    The point rate is `starters.marcel_rates`'s production path: a tuned,
+    age-curve-adjusted Marcel, not a ballast-on-a-count formula, so unlike the
+    hitter side it has no pseudo-counts to expose exactly. What it has instead:
+    the *legacy* path (`legacy=True`, `starters._marcel_rates_legacy`) runs the
+    same counts through the raw ballast formula and does have an exact Beta.
+    `alpha_k`/`beta_k` here take that Beta's total (alpha+beta — the raw
+    ballasted sample size, i.e. how much the ballast plus the observed batters
+    faced constrain the rate) and recentre it on the *tuned* `rate_k`, so the
+    posterior mean matches the price actually being sold while the posterior
+    width still comes from real sample size. This is named as an approximation
+    rather than hidden: it assumes the tuning (age curve, recency) changes the
+    rate's location and not its precision, which is untested.
+    """
     current = sp_model.appearances_before(inputs["game_logs"], as_of)
     counts = pd.concat([inputs["prior_counts"], current], ignore_index=True)
-    return sp_model.marcel_rates(counts, inputs["season"], inputs["league"],
-                                 ballast=ballast)
+    tuned = sp_model.marcel_rates(counts, inputs["season"], inputs["league"],
+                                  ballast=ballast)
+    if tuned.empty:
+        return tuned
+    raw = sp_model.marcel_rates(counts, inputs["season"], inputs["league"],
+                                ballast=ballast, legacy=True)
+    total_k = (raw["alpha_k"] + raw["beta_k"]).reindex(tuned.index)
+    # A pitcher the tuned provider prices but the raw ballast formula has no
+    # row for (should not happen off the same counts, but the two paths are
+    # different code) falls back to the ballast alone — still a real, if
+    # minimal, amount of precision, never a crash.
+    total_k = total_k.fillna(float(sp_model._ballast_map(ballast)["k"]))
+    tuned = tuned.copy()
+    tuned["alpha_k"] = total_k * tuned["rate_k"]
+    tuned["beta_k"] = total_k * (1.0 - tuned["rate_k"])
+    return tuned
 
 
 def starter_bf(inputs: dict, as_of: str, default: float = STARTER_BF,
@@ -315,11 +468,22 @@ def price(closes: pd.DataFrame, batter_ctx: dict, pitcher_ctx: dict,
 
     `pitcher_bf` is "fixed" (every start faces `STARTER_BF`) or "own" (the
     pitcher's own batters faced per start to date, `starter_bf`).
+
+    Two more columns carry the Beta-binomial marginal (BAS-70,
+    docs/posterior-props.md): `p_over_bb` is the Monte Carlo mean of
+    `P(over)` over the component Betas behind `p_model` (through the same
+    matchup adjustment as `p_matchup` when `matchup_ctx` is given, so the two
+    are the like-for-like comparison the pre-registration asks for — when
+    matchup is off it is the marginal counterpart of `p_model` instead), and
+    `p_over_sd` is the posterior standard deviation of `P(over)` across those
+    same draws — the number the vacuity check and the selection rule both
+    read by that name.
     """
     wanted = closes[closes["prop_stat"].isin(list(stats))
                     & closes["player_id"].notna()].copy()
     if wanted.empty:
-        cols = {"p_model": [], "p_league": [], "p_market": [], "exp_pa": []}
+        cols = {"p_model": [], "p_league": [], "p_market": [], "exp_pa": [],
+                "p_over_bb": [], "p_over_sd": []}
         if matchup_ctx is not None:
             cols["p_matchup"] = []
         return wanted.assign(**cols)
@@ -327,6 +491,7 @@ def price(closes: pd.DataFrame, batter_ctx: dict, pitcher_ctx: dict,
     lg_per_pa = pa_outcome_probs(
         {f"rate_{c}": lg[f"rate_{c}"] for c in lu_model.COMPONENTS}, lg)
     lg_k = pitcher_ctx["league"]["rate_k"]
+    rng = np.random.default_rng(MC_SEED)
 
     out = []
     for as_of, day in wanted.groupby("game_date", sort=True):
@@ -336,6 +501,12 @@ def price(closes: pd.DataFrame, batter_ctx: dict, pitcher_ctx: dict,
         mday = _matchup_day(matchup_ctx, as_of)
         per_pa_cache: dict[int, dict] = {}
         matchup_cache: dict = {}
+        # Monte Carlo draws, cached per player for this date so three lines on
+        # the same hits market (1+/2+/3+) share draws rather than resampling.
+        batter_draw_cache: dict[int, pd.DataFrame] = {}
+        batter_per_pa_draws_cache: dict[int, dict] = {}
+        batter_matchup_draws_cache: dict = {}
+        pitcher_draw_cache: dict[int, np.ndarray] = {}
         for row in day.itertuples(index=False):
             pid = int(row.player_id)
             extra = {}
@@ -346,11 +517,22 @@ def price(closes: pd.DataFrame, batter_ctx: dict, pitcher_ctx: dict,
                 pa = bf_lookup.get(pid, STARTER_BF)
                 p_model = pitcher_prop_prob("k", row.prop_line, rate, pa)
                 p_league = pitcher_prop_prob("k", row.prop_line, lg_k, pa)
+                if pid not in pitcher_draw_cache:
+                    pitcher_draw_cache[pid] = rng.beta(
+                        float(p_rates.loc[pid, "alpha_k"]),
+                        float(p_rates.loc[pid, "beta_k"]), size=MC_DRAWS)
+                rate_draws = pitcher_draw_cache[pid]
                 if mday is not None:
-                    adj = _pitcher_matchup_rate(mday, row, rate, b_rates, lg,
-                                                matchup_cache)
-                    extra["p_matchup"] = pitcher_prop_prob("k", row.prop_line,
-                                                           adj, pa)
+                    extra["p_matchup"] = _pitcher_matchup_rate(
+                        mday, row, rate, b_rates, lg, matchup_cache)
+                    extra["p_matchup"] = pitcher_prop_prob(
+                        "k", row.prop_line, extra["p_matchup"], pa)
+                    factor = _pitcher_matchup_factor(mday, row, b_rates, lg,
+                                                     matchup_cache)
+                    from src.market import matchup as mu
+                    rate_draws = mu.apply_factor(rate_draws, factor, mday["weight"])
+                extra["p_over_bb"], extra["p_over_sd"] = _pitcher_mc_price(
+                    row.prop_line, rate_draws, pa)
             else:
                 slot = slots.get((int(row.game_pk), pid))
                 if slot is None:            # not in the posted lineup
@@ -363,11 +545,39 @@ def price(closes: pd.DataFrame, batter_ctx: dict, pitcher_ctx: dict,
                                            per_pa_cache[pid], pa)
                 p_league = batter_prop_prob(row.prop_stat, row.prop_line,
                                             lg_per_pa, pa)
+                has_draws = pid in b_rates.index
+                if has_draws and pid not in batter_draw_cache:
+                    batter_draw_cache[pid] = _component_draws(b_rates.loc[pid], rng)
+                    batter_per_pa_draws_cache[pid] = _per_pa_draws(
+                        batter_draw_cache[pid], lg)
                 if mday is not None:
                     per_pa = _batter_matchup_per_pa(mday, row, pid, b_rates, lg,
                                                     matchup_cache)
                     extra["p_matchup"] = batter_prop_prob(
                         row.prop_stat, row.prop_line, per_pa, pa)
+                    if has_draws:
+                        side = mday["sides"].get((int(row.game_pk), pid))
+                        opp = {"home": "away", "away": "home"}.get(side)
+                        factors = _hitter_matchup_factors(mday, row, pid, matchup_cache)
+                        mkey = (pid, opp)
+                        if mkey not in batter_matchup_draws_cache:
+                            adj_draws = _apply_matchup_draws(
+                                batter_draw_cache[pid], factors, mday["weight"])
+                            batter_matchup_draws_cache[mkey] = _per_pa_draws(
+                                adj_draws, lg)
+                        per_pa_draws = batter_matchup_draws_cache[mkey]
+                    else:
+                        per_pa_draws = None
+                else:
+                    per_pa_draws = batter_per_pa_draws_cache.get(pid)
+                if per_pa_draws is not None:
+                    extra["p_over_bb"], extra["p_over_sd"] = _batter_mc_price(
+                        row.prop_stat, row.prop_line, per_pa_draws, pa)
+                else:
+                    # No player-specific rates (league fallback): no Beta to
+                    # marginalise over, so the marginal collapses onto the
+                    # point price with zero posterior width, honestly.
+                    extra["p_over_bb"], extra["p_over_sd"] = p_model, 0.0
             if mday is not None and "p_matchup" not in extra:
                 extra["p_matchup"] = p_model
             out.append({**row._asdict(), "exp_pa": pa,
@@ -401,9 +611,14 @@ def _matchup_day(matchup_ctx: dict | None, as_of: str) -> dict | None:
     return day
 
 
-def _batter_matchup_per_pa(mday: dict, row, pid: int, b_rates, lg: dict,
-                           cache: dict) -> dict:
-    """Per-PA outcome probabilities for one hitter against tonight's pitching."""
+def _hitter_matchup_factors(mday: dict, row, pid: int, cache: dict) -> dict:
+    """{component: factor} for the pitching one hitter is about to face.
+
+    Split out of `_batter_matchup_per_pa` so the Monte Carlo marginal
+    (`_apply_matchup_draws`) can apply the identical, identically-cached
+    factors to its component draws instead of to a point rate — the "same
+    adjustment" docs/posterior-props.md asks the marginal to go through.
+    """
     from src.market import matchup as mu
     game_pk = int(row.game_pk)
     side = mday["sides"].get((game_pk, pid))
@@ -414,19 +629,27 @@ def _batter_matchup_per_pa(mday: dict, row, pid: int, b_rates, lg: dict,
         team = mday["teams"].get((game_pk, opp)) if opp else None
         cache[key] = mu.hitter_factors(mday["tables"], mday["ctx"]["league"],
                                        sp, team)
-    factors = cache[key]
+    return cache[key]
+
+
+def _batter_matchup_per_pa(mday: dict, row, pid: int, b_rates, lg: dict,
+                           cache: dict) -> dict:
+    """Per-PA outcome probabilities for one hitter against tonight's pitching."""
+    from src.market import matchup as mu
+    factors = _hitter_matchup_factors(mday, row, pid, cache)
     rates = b_rates.loc[pid] if pid in b_rates.index else \
         {f"rate_{c}": lg[f"rate_{c}"] for c in lu_model.COMPONENTS}
     return pa_outcome_probs(mu.matchup_rates(rates, factors, mday["weight"]), lg)
 
 
-def _pitcher_matchup_rate(mday: dict, row, rate_k: float, b_rates, lg: dict,
-                          cache: dict) -> float:
-    """A starter's K per batter faced against the card he is about to face.
+def _pitcher_matchup_factor(mday: dict, row, b_rates, lg: dict, cache: dict) -> float:
+    """The opposing card's strikeout factor a starter is about to face.
 
     The opposing club's posted card where one exists, its recent cards where
     it does not, and the league — a factor of exactly 1.0 — where neither
-    does, which leaves the price where the current model put it.
+    does, which leaves the price where the current model put it. Split out of
+    `_pitcher_matchup_rate` so the Monte Carlo marginal can apply the same
+    cached factor to an array of `rate_k` draws instead of one point rate.
     """
     from src.market import matchup as mu
     game_pk = int(row.game_pk)
@@ -450,7 +673,15 @@ def _pitcher_matchup_rate(mday: dict, row, rate_k: float, b_rates, lg: dict,
                                         mday["as_of"]) if opp_team else []
             f = mu.card_k_factor(recent, b_rates, lg["rate_k"]) or 1.0
         cache[key] = f
-    return float(mu.apply_factor(rate_k, cache[key], mday["weight"]))
+    return float(cache[key])
+
+
+def _pitcher_matchup_rate(mday: dict, row, rate_k: float, b_rates, lg: dict,
+                          cache: dict) -> float:
+    """A starter's K per batter faced against the card he is about to face."""
+    from src.market import matchup as mu
+    factor = _pitcher_matchup_factor(mday, row, b_rates, lg, cache)
+    return float(mu.apply_factor(rate_k, factor, mday["weight"]))
 
 
 # ───────────────────────────── scoring ─────────────────────────────

--- a/src/sim/lineups.py
+++ b/src/sim/lineups.py
@@ -209,15 +209,27 @@ def marcel_rates(counts: pd.DataFrame, as_of_season: int, lg: dict,
     (or at-bats, or balls in play). `ballast` is either one number for every
     component or a {component: sample} mapping (the default, `BALLAST`).
 
-    Returns a frame indexed by batter with the five rate columns and
-    `pa_weighted` (the effective sample). A batter with no history is simply
-    absent — `batter_runs_lookup` gives those league average.
+    Returns a frame indexed by batter with the five rate columns, `pa_weighted`
+    (the effective sample), and `alpha_<c>` / `beta_<c>` for each component —
+    the pseudo-counts of the Beta posterior the rate is the mean of:
+
+        alpha_c = num_w + ballast_c * lg_c
+        beta_c  = (den_w - num_w) + ballast_c * (1 - lg_c)
+
+    so `alpha_c / (alpha_c + beta_c) == rate_c` exactly (pinned in
+    `tests/test_sim/test_lineups.py`). `src/market/props.py` draws from these
+    to price the marginal `P(over)` instead of the point rate (BAS-70,
+    docs/posterior-props.md) — the Beta was already implicit in the ballast
+    arithmetic above, this just returns the two numbers that define it instead
+    of collapsing them into their ratio.
     """
     w = {as_of_season - i: weights[i] / weights[0] for i in range(len(weights))}
     used = counts[counts["season"].isin(w)].copy()
     num_den = sorted(set(RATE_NUM.values()) | set(RATE_DEN.values()))
     if used.empty:
-        return pd.DataFrame(columns=["pa_weighted", *RATE_COLS],
+        cols = ["pa_weighted", *RATE_COLS,
+                *[f"alpha_{c}" for c in COMPONENTS], *[f"beta_{c}" for c in COMPONENTS]]
+        return pd.DataFrame(columns=cols,
                             index=pd.Index([], name="batter", dtype="int64"))
     ws = used["season"].map(w).astype(float)
     for col in num_den:
@@ -228,7 +240,10 @@ def marcel_rates(counts: pd.DataFrame, as_of_season: int, lg: dict,
     out["pa_weighted"] = agg["pa"]
     for c in COMPONENTS:
         num, den = agg[RATE_NUM[c]], agg[RATE_DEN[c]]
-        out[f"rate_{c}"] = ((num + bal[c] * lg[f"rate_{c}"]) / (den + bal[c]))
+        lgc = lg[f"rate_{c}"]
+        out[f"rate_{c}"] = (num + bal[c] * lgc) / (den + bal[c])
+        out[f"alpha_{c}"] = num + bal[c] * lgc
+        out[f"beta_{c}"] = (den - num) + bal[c] * (1.0 - lgc)
     return out
 
 

--- a/src/sim/starters.py
+++ b/src/sim/starters.py
@@ -248,11 +248,23 @@ def _marcel_rates_legacy(counts: pd.DataFrame, as_of_season: int, lg: dict,
                          weights: tuple = MARCEL_WEIGHTS,
                          ballast=BALLAST_BF) -> pd.DataFrame:
     """The pre-provider arithmetic, kept as the reference the provider is
-    pinned against. Nothing in production calls it."""
+    pinned against. Nothing in production calls it for the point price.
+
+    Also the only place a pitcher's rate has an explicit Beta behind it: the
+    production path (`legacy=False`) runs the count through `marcel_tuned`'s
+    age curve, which is not a ballast-on-a-count formula and has no pseudo-
+    counts to expose. `alpha_<c>`/`beta_<c>` here reproduce *this* function's
+    own `rate_<c>` exactly, same as `lineups.marcel_rates`; `src/market/props.py`
+    uses their total (alpha+beta, the raw ballasted sample size) rescaled onto
+    the tuned mean as an approximate posterior for pitcher strikeouts, and
+    says so where it does it.
+    """
     w = {as_of_season - i: weights[i] / weights[0] for i in range(len(weights))}
     used = counts[counts["season"].isin(w)].copy()
     if used.empty:
-        return pd.DataFrame(columns=["bf_weighted", *RATE_COLS],
+        cols = ["bf_weighted", *RATE_COLS,
+                *[f"alpha_{c}" for c in COMPONENTS], *[f"beta_{c}" for c in COMPONENTS]]
+        return pd.DataFrame(columns=cols,
                             index=pd.Index([], name="pitcher", dtype="int64"))
     ws = used["season"].map(w).astype(float)
     for col in ("bf", *COMPONENTS):
@@ -262,8 +274,10 @@ def _marcel_rates_legacy(counts: pd.DataFrame, as_of_season: int, lg: dict,
     out = pd.DataFrame(index=agg.index)
     out["bf_weighted"] = agg["bf"]
     for c in COMPONENTS:
-        out[f"rate_{c}"] = ((agg[c] + bal[c] * lg[f"rate_{c}"])
-                            / (agg["bf"] + bal[c]))
+        lgc = lg[f"rate_{c}"]
+        out[f"rate_{c}"] = (agg[c] + bal[c] * lgc) / (agg["bf"] + bal[c])
+        out[f"alpha_{c}"] = agg[c] + bal[c] * lgc
+        out[f"beta_{c}"] = (agg["bf"] - agg[c]) + bal[c] * (1.0 - lgc)
     return out
 
 

--- a/tests/test_market/test_posterior_kelly.py
+++ b/tests/test_market/test_posterior_kelly.py
@@ -1,0 +1,93 @@
+"""Pins the correction in docs/posterior-props.md: for a one-shot binary
+contract, the stake that maximises *posterior*-expected log growth is
+exactly `kelly_stake` evaluated at the posterior mean — not something
+shaded down for parameter uncertainty.
+
+modelling-roadmap.md §1 claimed "Kelly under parameter uncertainty is
+provably not Kelly at the mean; the correct stake shades down." That is
+true for some problems (repeated bets against one persistent unknown `p`,
+or a payoff nonlinear in `p`) but false for the thing this repo actually
+prices: a single binary contract bought at cost `c`, paying $1. There,
+
+    E[log W | p] = p · log(1 + f(1−c)/c) + (1 − p) · log(1 − f)
+
+is *linear* in `p`, so ``E_q[E[log W | p]] = E[log W | E_q[p]]`` for any
+posterior `q` — the plug-in stake at the mean is already the posterior
+optimum, with no correction term. This test does not trust that algebra;
+it numerically maximises the posterior-expected log growth over `f` for
+several Beta posteriors and checks the maximiser lands on `kelly_stake` at
+the posterior mean.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.optimize import minimize_scalar
+from scipy.stats import beta as beta_dist, qmc
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.market import pnl
+
+# (alpha, beta) pairs spanning posterior means 0.55-0.70 and sds ~0.01-0.15.
+# A Beta(a, b) has mean a/(a+b) and sd sqrt(ab / ((a+b)^2 (a+b+1))); these
+# were picked to hit that range with a mix of tight (large a+b, many
+# pseudo-observations) and loose (small a+b) posteriors.
+BETA_PARAMS = [
+    (5_500, 4_500),     # mean .55, sd ~0.0050 (tight — lots of at-bats)
+    (55, 45),            # mean .55, sd ~0.0495
+    (11, 9),              # mean .55, sd ~0.1086 (loose — a handful of PAs)
+    (1_200, 800),        # mean .60, sd ~0.0110
+    (60, 40),             # mean .60, sd ~0.0487
+    (6, 4),                # mean .60, sd ~0.1477
+    (2_100, 900),        # mean .70, sd ~0.0084
+    (70, 30),             # mean .70, sd ~0.0456
+    (14, 6),               # mean .70, sd ~0.1000
+]
+
+COST = 0.40    # an arbitrary but representative contract price
+
+
+def posterior_expected_log_growth(f, a, b, cost, draws):
+    """Monte-Carlo E_q[log W(f)] for q = Beta(a, b), used only to locate the
+    optimum numerically — not the closed form the test is checking against.
+    """
+    if f <= 0.0 or f >= 1.0:
+        return 1e9  # keep the optimizer inside the feasible stake range
+    p = draws
+    win = np.log1p(f * (1 - cost) / cost)
+    lose = np.log1p(-f)
+    return -float(np.mean(p * win + (1 - p) * lose))  # negated: we minimize
+
+
+@pytest.mark.parametrize("a,b", BETA_PARAMS)
+def test_posterior_optimal_stake_is_kelly_at_the_mean(a, b):
+    mean = a / (a + b)
+    sd = (a * b / ((a + b) ** 2 * (a + b + 1))) ** 0.5
+    assert 0.55 - 1e-6 <= mean <= 0.70 + 1e-6
+    assert 0.004 <= sd <= 0.15
+
+    # Several seeds, large draw count: the numerical optimum has to be
+    # stable, not an artefact of one Monte-Carlo sample. Plain pseudo-random
+    # draws need tens of millions of points to pin f to 1e-4 (the log-growth
+    # integrand is smooth, so most of that is wasted); scrambled Sobol draws
+    # transformed through the Beta's inverse CDF converge far faster for the
+    # same point count, so 2**20 points per seed is enough.
+    optimal_fs = []
+    for seed in (0, 1, 2):
+        sampler = qmc.Sobol(d=1, scramble=True, seed=seed)
+        u = sampler.random_base2(m=20).ravel()
+        draws = beta_dist.ppf(u, a, b)
+        result = minimize_scalar(
+            posterior_expected_log_growth, args=(a, b, COST, draws),
+            bounds=(1e-6, 1.0 - 1e-6), method="bounded",
+            options={"xatol": 1e-10})
+        optimal_fs.append(result.x)
+
+    numerical = float(np.mean(optimal_fs))
+    plugin = pnl.kelly_stake(mean, COST, fraction=1.0, cap=1.0, bankroll=1.0)
+    assert numerical == pytest.approx(float(plugin), abs=1e-4)
+    # And the seeds agree with each other to well inside that tolerance —
+    # the numerical search, not just its mean, is stable.
+    assert max(optimal_fs) - min(optimal_fs) < 2e-4

--- a/tests/test_market/test_posterior_selection.py
+++ b/tests/test_market/test_posterior_selection.py
@@ -1,0 +1,180 @@
+"""`decide_posterior` — selecting on P(edge > 0) instead of |mean edge|.
+
+docs/posterior-props.md's second prediction is that this beats the
+threshold rule at a matched bet count, because the threshold rule cannot
+tell a real 3-point edge from a 3-point edge sitting on a wide posterior.
+These tests are about the mechanics the prediction depends on: the
+degenerate case (a point posterior must reduce to the existing rule
+exactly), monotonicity in `p_sd`, and that it never trades inside the
+spread — plus that `decide` itself, and everything built on it, is
+untouched.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.market import pnl
+
+
+# ───────────────────────────── decide_posterior ─────────────────────────────
+
+def test_zero_sd_reduces_to_the_threshold_rule_at_zero():
+    rng = np.random.default_rng(0)
+    n = 200
+    p = rng.uniform(0.1, 0.9, n)
+    mid = rng.uniform(0.1, 0.9, n)
+    bid, ask = mid - 0.02, mid + 0.02
+    sd = np.zeros(n)
+
+    baseline = pnl.decide(p, bid, ask, threshold=0.0)
+    for tau in (0.1, 0.5, 0.55, 0.9, 0.99):
+        posterior = pnl.decide_posterior(p, sd, bid, ask, tau)
+        assert list(posterior["side"]) == list(baseline["side"])
+        pd.testing.assert_series_equal(
+            posterior["cost"], baseline["cost"], check_names=False)
+        pd.testing.assert_series_equal(
+            posterior["edge"], baseline["edge"], check_names=False)
+
+
+def test_wider_posterior_bets_less_at_fixed_mean_edge_and_tau():
+    # Fix the mean edge (p − ask = 0.03 throughout) and grow the posterior
+    # sd: P(p_true > ask) shrinks toward 0.5 as the Normal widens around a
+    # mean that is only barely on the right side of ask, so fewer contracts
+    # clear any fixed tau > 0.5.
+    n = 500
+    ask = np.full(n, 0.50)
+    bid = np.full(n, 0.46)
+    p = np.full(n, 0.53)          # a constant 3-point mean edge
+    tau = 0.75
+    sds = [0.01, 0.02, 0.04, 0.08, 0.16, 0.32]
+    n_bets = []
+    for sd in sds:
+        d = pnl.decide_posterior(p, np.full(n, sd), bid, ask, tau)
+        n_bets.append(int((d["side"] != pnl.NO_BET).sum()))
+    # All rows are identical, so each sd gives either "everyone bets" (0 or
+    # n) or, at the crossover, could tip either way for all of them at once
+    # — the count is non-increasing as sd grows.
+    assert n_bets == sorted(n_bets, reverse=True)
+    assert n_bets[0] == n            # sd=0.01: mean edge is ~3 sds out, easy bet
+    assert n_bets[-1] == 0           # sd=0.32: mean edge is a rounding error
+
+
+def test_wider_posterior_bets_less_across_a_mixed_book():
+    # Same monotonicity claim with a realistic mix of edges rather than one
+    # repeated row, comparing bet counts between two fixed sd levels.
+    rng = np.random.default_rng(1)
+    n = 2_000
+    mid = rng.uniform(0.2, 0.8, n)
+    bid, ask = mid - 0.02, mid + 0.02
+    edge_sign = rng.choice([-1, 1], n)
+    p = np.clip(mid + edge_sign * rng.uniform(0.0, 0.06, n), 0.01, 0.99)
+    tau = 0.7
+
+    tight = pnl.decide_posterior(p, np.full(n, 0.01), bid, ask, tau)
+    loose = pnl.decide_posterior(p, np.full(n, 0.06), bid, ask, tau)
+    n_tight = int((tight["side"] != pnl.NO_BET).sum())
+    n_loose = int((loose["side"] != pnl.NO_BET).sum())
+    assert n_loose < n_tight
+
+
+def test_never_bets_inside_the_spread_for_tau_at_or_above_half():
+    rng = np.random.default_rng(2)
+    n = 5_000
+    mid = rng.uniform(0.05, 0.95, n)
+    half_spread = rng.uniform(0.005, 0.04, n)
+    bid, ask = mid - half_spread, mid + half_spread
+    p = rng.uniform(0.0, 1.0, n)                 # includes plenty inside [bid, ask]
+    sd = rng.uniform(0.001, 0.3, n)
+
+    for tau in (0.5, 0.6, 0.75, 0.9):
+        d = pnl.decide_posterior(p, sd, bid, ask, tau)
+        yes = d["side"].to_numpy() == "yes"
+        no = d["side"].to_numpy() == "no"
+        assert np.all(p[yes] > ask[yes])
+        assert np.all(p[no] < bid[no])
+
+
+def test_decide_posterior_never_bets_when_posterior_probability_below_tau():
+    # A near-certain 1-point edge (tiny sd) should not clear a high tau even
+    # though `decide` would take it at threshold 0.
+    p = np.array([0.51])
+    bid, ask = np.array([0.48]), np.array([0.50])
+    sd = np.array([0.01])          # edge is ~1 sd out — clears a modest tau
+    assert pnl.decide_posterior(p, sd, bid, ask, 0.8)["side"][0] == "yes"
+
+    sd_wide = np.array([2.0])      # same edge, huge sd — should not clear tau
+    assert pnl.decide_posterior(p, sd_wide, bid, ask, 0.6)["side"][0] == pnl.NO_BET
+
+
+# ───────────────────────────── decide is untouched ─────────────────────────────
+
+def test_existing_decide_behaviour_is_unchanged():
+    p = np.array([0.10, 0.52, 0.60, 0.90])
+    bid = np.array([0.05, 0.50, 0.55, 0.85])
+    ask = np.array([0.15, 0.54, 0.65, 0.95])
+    d = pnl.decide(p, bid, ask, threshold=0.0)
+    assert list(d["side"]) == [pnl.NO_BET, pnl.NO_BET, pnl.NO_BET, pnl.NO_BET]
+    d2 = pnl.decide(p, bid, ask, threshold=0.0)
+    d3 = pnl.decide(np.array([0.20]), np.array([0.05]), np.array([0.15]), 0.0)
+    assert d3["side"][0] == "yes"
+    assert d3["cost"][0] == pytest.approx(0.15)
+    assert d3["edge"][0] == pytest.approx(0.05)
+    pd.testing.assert_frame_equal(d, d2)
+
+
+# ───────────────────────────── bet_frame / evaluate rule threading ─────────────────────────────
+
+def games(p_model, p_close, home_won, bid=None, ask=None, model="m", sd=None):
+    n = len(p_model)
+    bid = [c - 0.01 for c in p_close] if bid is None else bid
+    ask = [c + 0.01 for c in p_close] if ask is None else ask
+    d = {
+        "date": [f"2026-07-{i + 1:02d}" for i in range(n)],
+        "game_pk": range(1, n + 1),
+        "home_win": home_won,
+        model: p_model,
+        "p_home_close": p_close,
+        "bid": bid,
+        "ask": ask,
+    }
+    if sd is not None:
+        d["p_over_sd"] = sd
+    return pd.DataFrame(d)
+
+
+def test_bet_frame_default_rule_is_unchanged_by_the_new_argument():
+    df = games([0.10, 0.60], [0.30, 0.50], [False, True])
+    old = pnl.bet_frame(df, "m", pnl.KALSHI, threshold=0.02)
+    new = pnl.bet_frame(df, "m", pnl.KALSHI, threshold=0.02, rule="threshold")
+    pd.testing.assert_frame_equal(old, new)
+
+
+def test_bet_frame_posterior_rule_uses_sd_col_and_tau():
+    df = games([0.10, 0.60], [0.30, 0.50], [False, True],
+              sd=[0.005, 0.20])
+    bets = pnl.bet_frame(df, "m", pnl.KALSHI, rule="posterior", tau=0.9,
+                         sd_col="p_over_sd")
+    # Row 0: edge is far from the spread relative to its tiny sd -> bets.
+    # Row 1: same-sized nominal edge but a wide sd -> does not clear tau=0.9.
+    assert len(bets) == 1
+    assert bets.iloc[0]["game_pk"] == 1
+
+
+def test_bet_frame_posterior_rule_requires_sd_col_and_tau():
+    df = games([0.10], [0.30], [False])
+    with pytest.raises(ValueError):
+        pnl.bet_frame(df, "m", pnl.KALSHI, rule="posterior")
+
+
+def test_evaluate_threads_rule_through_and_reports_it():
+    df = games([0.10, 0.60], [0.30, 0.50], [False, True], sd=[0.005, 0.20])
+    row = pnl.evaluate(df, "m", pnl.KALSHI, rule="posterior", tau=0.9,
+                       sd_col="p_over_sd")
+    assert row["rule"] == "posterior"
+    assert row["tau"] == 0.9
+    assert row["n_bets"] == 1

--- a/tests/test_market/test_props.py
+++ b/tests/test_market/test_props.py
@@ -10,6 +10,7 @@ import sys
 from math import comb, exp
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -244,6 +245,135 @@ def test_a_better_hitter_prices_higher_at_the_same_line():
     # A higher line is always less likely.
     assert props.batter_prop_prob("hits", 1.5, good, 4.6) < \
         props.batter_prop_prob("hits", 0.5, good, 4.6)
+
+
+# ───────────────────────── the Beta-binomial marginal (BAS-70) ─────────────
+
+MC_LG = {"rate_k": 0.22, "rate_bbhbp": 0.09, "rate_hr": 0.032, "rate_iso": 0.16,
+        "rate_babip": 0.295, "nonab_share": 0.02, "sf_share": 0.005,
+        "triple_share": 0.08}
+
+
+def _rates_row(rate_k, rate_bbhbp, rate_hr, rate_iso, rate_babip, total):
+    """A `lineups.marcel_rates` row with pseudo-counts at a given total sample.
+
+    `total` is `alpha_c + beta_c` for every component, held equal across
+    components for a clean single knob on "how much sample backs this rate" —
+    real rows have a different total per component (BABIP's ballast alone is
+    820 PA), but the mock doesn't need that to exercise the marginal.
+    """
+    rates = {"rate_k": rate_k, "rate_bbhbp": rate_bbhbp, "rate_hr": rate_hr,
+             "rate_iso": rate_iso, "rate_babip": rate_babip}
+    row = dict(rates)
+    for c, r in rates.items():
+        comp = c.split("_", 1)[1]
+        row[f"alpha_{comp}"] = total * r
+        row[f"beta_{comp}"] = total * (1.0 - r)
+    return pd.Series(row)
+
+
+def test_alpha_beta_reproduce_the_point_rate_in_a_prop_context():
+    row = _rates_row(0.22, 0.09, 0.032, 0.16, 0.295, total=500.0)
+    for c in props.lu_model.COMPONENTS:
+        a, b = row[f"alpha_{c}"], row[f"beta_{c}"]
+        assert a / (a + b) == pytest.approx(row[f"rate_{c}"], abs=1e-12)
+
+
+def test_marginal_equals_point_price_when_the_beta_is_degenerate():
+    """A near-infinite pseudo-count sample: the Beta collapses onto its mean,
+    so the marginal must equal the point price to within Monte Carlo error."""
+    row = _rates_row(0.22, 0.09, 0.032, 0.16, 0.295, total=1e9)
+    per_pa = props.pa_outcome_probs(row, MC_LG)
+    pa = 4.3
+    rng = np.random.default_rng(0)
+    draws = props._component_draws(row, rng, n=props.MC_DRAWS)
+    per_pa_draws = props._per_pa_draws(draws, MC_LG)
+    for stat, line in (("hits", 0.5), ("hr", 0.5), ("tb", 1.5)):
+        point = props.batter_prop_prob(stat, line, per_pa, pa)
+        mean, sd = props._batter_mc_price(stat, line, per_pa_draws, pa)
+        assert mean == pytest.approx(point, abs=0.005)
+        assert sd == pytest.approx(0.0, abs=1e-3)
+
+
+def test_marginal_exceeds_point_price_at_a_tail_line_with_a_wide_beta():
+    """The convexity claim in docs/posterior-props.md: at a low-probability
+    tail line (2+ HR at a low HR rate) with real uncertainty in the rate, the
+    marginal over the Beta prices *higher* than the point estimate — the
+    point price is a plug-in at the mean of a convex function."""
+    row = _rates_row(0.24, 0.08, 0.02, 0.12, 0.28, total=40.0)  # thin sample
+    per_pa = props.pa_outcome_probs(row, MC_LG)
+    pa = 4.3
+    rng = np.random.default_rng(1)
+    draws = props._component_draws(row, rng, n=props.MC_DRAWS)
+    per_pa_draws = props._per_pa_draws(draws, MC_LG)
+    point = props.batter_prop_prob("hr", 1.5, per_pa, pa)   # 2+ HR
+    mean, sd = props._batter_mc_price("hr", 1.5, per_pa_draws, pa)
+    assert mean > point
+    assert sd > 0.0
+
+
+def test_p_over_sd_is_zero_only_when_the_beta_is_degenerate():
+    tight = _rates_row(0.22, 0.09, 0.032, 0.16, 0.295, total=1e9)
+    loose = _rates_row(0.22, 0.09, 0.032, 0.16, 0.295, total=200.0)
+    rng = np.random.default_rng(2)
+    for row, expect_zero in ((tight, True), (loose, False)):
+        draws = props._component_draws(row, rng, n=props.MC_DRAWS)
+        per_pa_draws = props._per_pa_draws(draws, MC_LG)
+        _, sd = props._batter_mc_price("hits", 0.5, per_pa_draws, 4.3)
+        if expect_zero:
+            assert sd == pytest.approx(0.0, abs=1e-3)
+        else:
+            assert sd > 0.001
+
+
+def test_pitcher_marginal_behaves_the_same_way():
+    rng = np.random.default_rng(3)
+    tight_draws = rng.beta(0.22 * 1e9, 0.78 * 1e9, size=props.MC_DRAWS)
+    loose_draws = rng.beta(0.22 * 60.0, 0.78 * 60.0, size=props.MC_DRAWS)
+    pa = 23.0
+    point = props.pitcher_prop_prob("k", 7.5, 0.22, pa)
+    mean_tight, sd_tight = props._pitcher_mc_price(7.5, tight_draws, pa)
+    mean_loose, sd_loose = props._pitcher_mc_price(7.5, loose_draws, pa)
+    assert mean_tight == pytest.approx(point, abs=0.005)
+    assert sd_tight == pytest.approx(0.0, abs=1e-3)
+    assert sd_loose > 0.0
+
+
+def test_monte_carlo_error_is_small_at_the_production_draw_count():
+    """Two independent seeds at MC_DRAWS should agree well inside the 0.005
+    posterior-sd threshold docs/posterior-props.md's vacuity check uses —
+    otherwise the draw count is too small to trust the reported p_over_sd."""
+    row = _rates_row(0.24, 0.08, 0.02, 0.12, 0.28, total=40.0)
+    per_pa_a = props._per_pa_draws(
+        props._component_draws(row, np.random.default_rng(10), n=props.MC_DRAWS), MC_LG)
+    per_pa_b = props._per_pa_draws(
+        props._component_draws(row, np.random.default_rng(11), n=props.MC_DRAWS), MC_LG)
+    mean_a, _ = props._batter_mc_price("hr", 1.5, per_pa_a, 4.3)
+    mean_b, _ = props._batter_mc_price("hr", 1.5, per_pa_b, 4.3)
+    assert abs(mean_a - mean_b) < 0.001
+
+
+def test_price_frame_carries_the_marginal_columns_without_disturbing_the_rest():
+    ctx = _batter_ctx()
+    pitchers = {"season": 2026, "league": {"rate_k": 0.22},
+                "prior_counts": pd.DataFrame(columns=["pitcher", "season", "bf", "k",
+                                                      "bbhbp", "hr", "outs"]),
+                "game_logs": pd.DataFrame(columns=["pitcher", "season", "bf", "k",
+                                                   "bbhbp", "hr", "outs", "date"])}
+    closes = pd.DataFrame([
+        {"game_pk": 700001, "game_date": "2026-08-15", "player_id": 2,
+         "prop_stat": "hr", "prop_line": 0.5, "p_over_close": 0.12, "over_hit": True},
+    ])
+    slots = {(700001, 2): 3}
+    before = props.price(closes, ctx, pitchers, slots, stats=("hr",))
+    # p_model must still be exactly what `batter_prop_prob` gives directly off
+    # `batter_rates` — the point price is untouched by adding the marginal.
+    per_pa_cache_check = props.pa_outcome_probs(
+        props.batter_rates(ctx, "2026-08-15").loc[2], ctx["league"])
+    direct = props.batter_prop_prob("hr", 0.5, per_pa_cache_check, props.SLOT_PA[3])
+    assert before.loc[0, "p_model"] == pytest.approx(direct)
+    assert "p_over_bb" in before.columns and "p_over_sd" in before.columns
+    assert before.loc[0, "p_over_sd"] >= 0.0
 
 
 def test_unpriceable_stats_raise_rather_than_guess():

--- a/tests/test_scripts/test_props_exam_posterior.py
+++ b/tests/test_scripts/test_props_exam_posterior.py
@@ -1,0 +1,226 @@
+"""BAS-70 selection: the walk-forward tau chooser and the matched-bet-count
+comparison in scripts/props_exam.py.
+
+These build synthetic pnl-frame-shaped data carrying `p_over_sd` — the
+column BAS-70's other half (src/market/props.py, built in parallel and not
+in this worktree) is expected to add — rather than running the real props
+archive end to end.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "props_exam", ROOT / "scripts/props_exam.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+props_exam = _load()
+from src.market import pnl  # noqa: E402
+
+
+def synthetic_frame(n_per_half=300, seed=0):
+    """A pnl-frame-shaped table with a first half where a tight tau wins and
+    a second half where a loose tau wins — so the chooser has something to
+    get wrong if it looks at the wrong half.
+
+    Every row is a genuine edge (`p_model` on the correct side of the
+    market) with a Normal-ish `p_over_sd`; win/loss is drawn so that rows
+    with a *small* sd win more often in the first half (rewarding a tight
+    tau there) and rows with a *large* sd win more often in the second half
+    (rewarding a loose tau there) — engineered, not organic, purely to give
+    the chooser a half-dependent answer to find.
+    """
+    rng = np.random.default_rng(seed)
+
+    def half(date_prefix, n, favor_tight):
+        mid = rng.uniform(0.3, 0.7, n)
+        half_spread = 0.02
+        bid, ask = mid - half_spread, mid + half_spread
+        side_up = rng.choice([True, False], n)
+        edge_mag = rng.uniform(0.03, 0.08, n)
+        p_model = np.where(side_up, ask + edge_mag, bid - edge_mag)
+        p_model = np.clip(p_model, 0.02, 0.98)
+        sd = rng.uniform(0.01, 0.12, n)
+        # Win probability: correlated with small sd in the "tight" half,
+        # with large sd in the "loose" half — engineered so ROI genuinely
+        # differs by tau between halves.
+        tight_bonus = (0.12 - sd) / 0.12          # in [0, 1], big when sd small
+        loose_bonus = (sd - 0.01) / 0.11           # in [0, 1], big when sd big
+        p_win = 0.5 + 0.35 * (tight_bonus if favor_tight else loose_bonus)
+        home_won_up = rng.uniform(0, 1, n) < p_win
+        home_won = np.where(side_up, home_won_up, ~home_won_up)
+        return pd.DataFrame({
+            "date": [f"{date_prefix}-{i % 27 + 1:02d}" for i in range(n)],
+            "game_pk": np.arange(n) + (0 if date_prefix.endswith("07") else 10_000),
+            "prop_stat": rng.choice(["hits", "hr"], n),
+            "model": p_model,
+            "p_home_close": mid,
+            "bid": bid, "ask": ask,
+            "home_win": home_won,
+            "p_over_sd": sd,
+        })
+
+    first = half("2026-07", n_per_half, favor_tight=True)
+    second = half("2026-08", n_per_half, favor_tight=False)
+    return pd.concat([first, second], ignore_index=True), "2026-08-01"
+
+
+# ───────────────────────────── choose_tau ─────────────────────────────
+
+def test_choose_tau_only_looks_at_the_first_half():
+    frame, cut = synthetic_frame()
+    venue = props_exam.venue_for(0.0, False)
+    tau, table = props_exam.choose_tau(frame, "model", "p_over_sd", cut, venue,
+                                       grid=props_exam.TAU_GRID)
+    assert not np.isnan(tau)
+    assert tau in props_exam.TAU_GRID
+
+    # Sanity: the table itself is computed only on rows before `cut`.
+    train = frame[frame["date"].astype(str) < cut]
+    row = pnl.evaluate(train, "model", venue, staking="flat",
+                       group_col="game_pk", rule="posterior", tau=tau,
+                       sd_col="p_over_sd")
+    matching = table[np.isclose(table["tau"], tau)]
+    assert len(matching) == 1
+    assert matching.iloc[0]["n_bets"] == row["n_bets"]
+    assert matching.iloc[0]["roi"] == pytest.approx(row["roi"])
+
+    # The chooser must be blind to the second half: replacing it entirely
+    # (with rows that would favour a very different tau) does not change
+    # the choice, because the first half alone determines it.
+    poisoned_second = frame[frame["date"].astype(str) >= cut].copy()
+    poisoned_second["model"] = 1.0 - poisoned_second["model"]  # nonsense
+    poisoned = pd.concat([frame[frame["date"].astype(str) < cut],
+                          poisoned_second], ignore_index=True)
+    tau2, _ = props_exam.choose_tau(poisoned, "model", "p_over_sd", cut, venue,
+                                    grid=props_exam.TAU_GRID)
+    assert tau2 == tau
+
+
+def test_choose_tau_picks_the_half_where_the_best_tau_actually_differs():
+    # A frame explicitly engineered so the best tau on the first half is
+    # different from the best tau on the second half; the chooser must
+    # report the first half's answer.
+    rng = np.random.default_rng(7)
+    n = 400
+    mid = rng.uniform(0.3, 0.7, n)
+    bid, ask = mid - 0.02, mid + 0.02
+    side_up = rng.choice([True, False], n)
+    p_model = np.where(side_up, ask + 0.05, bid - 0.05)
+    sd_first = np.full(n, 0.01)   # first half: tiny sd -> any tau clears easily
+    sd_second = np.full(n, 0.20)  # second half: huge sd -> only low tau clears
+
+    def frame_half(prefix, sd, win_rate):
+        home_won_up = rng.uniform(0, 1, n) < win_rate
+        home_won = np.where(side_up, home_won_up, ~home_won_up)
+        return pd.DataFrame({
+            "date": [f"{prefix}-{i % 27 + 1:02d}" for i in range(n)],
+            "game_pk": np.arange(n) + (0 if prefix == "2026-07" else 10_000),
+            "model": p_model, "p_home_close": mid, "bid": bid, "ask": ask,
+            "home_win": home_won, "p_over_sd": sd,
+        })
+
+    first = frame_half("2026-07", sd_first, 0.62)
+    second = frame_half("2026-08", sd_second, 0.62)
+    frame = pd.concat([first, second], ignore_index=True)
+    cut = "2026-08-01"
+    venue = props_exam.venue_for(0.0, False)
+
+    # On the first half every tau in the grid clears (sd tiny), so ROI is
+    # flat across taus there and the chooser's tie-break keeps the least
+    # selective (largest bet count) tau -> the grid's smallest tau.
+    tau, table = props_exam.choose_tau(first, "model", "p_over_sd", cut, venue,
+                                       grid=props_exam.TAU_GRID)
+    assert tau == min(props_exam.TAU_GRID)
+
+    # Feeding the chooser only the second half instead gives a different
+    # answer (or at least a different bet-count profile at the high end of
+    # the grid, since the huge sd there strands the strict taus at 0 bets).
+    tau_on_second, table_second = props_exam.choose_tau(
+        second, "model", "p_over_sd", "2026-09-01", venue, grid=props_exam.TAU_GRID)
+    high_tau_row = table_second[np.isclose(table_second["tau"], max(props_exam.TAU_GRID))]
+    assert int(high_tau_row.iloc[0]["n_bets"]) == 0
+
+    # And on the combined frame, cut correctly at 2026-08-01, the chooser
+    # reproduces the first-half-only answer, not something in between.
+    tau_combined, _ = props_exam.choose_tau(frame, "model", "p_over_sd", cut,
+                                            venue, grid=props_exam.TAU_GRID)
+    assert tau_combined == tau
+
+
+# ───────────────────────────── matched_threshold ─────────────────────────────
+
+def test_matched_threshold_finds_a_comparable_bet_count():
+    frame, cut = synthetic_frame()
+    second = frame[frame["date"].astype(str) >= cut].reset_index(drop=True)
+    venue = props_exam.venue_for(0.0, False)
+    target = 40
+    t = props_exam.matched_threshold(second, "model", venue, target)
+    n = len(pnl.bet_frame(second, "model", venue, threshold=t))
+    # Bisection on a step function cannot always land exactly on the target;
+    # it should get close, and never wildly off for a target well inside the
+    # achievable range.
+    assert abs(n - target) <= max(5, int(0.1 * target))
+
+
+def test_matched_threshold_zero_target_gives_zero_bets_at_some_threshold():
+    frame, cut = synthetic_frame()
+    second = frame[frame["date"].astype(str) >= cut].reset_index(drop=True)
+    venue = props_exam.venue_for(0.0, False)
+    t = props_exam.matched_threshold(second, "model", venue, 0, hi=0.30)
+    n = len(pnl.bet_frame(second, "model", venue, threshold=t))
+    assert n == 0
+
+
+# ───────────────────────────── posterior_comparison ─────────────────────────────
+
+def test_posterior_comparison_has_matched_bet_count_between_posterior_and_matched_rows():
+    frame, cut = synthetic_frame()
+    second = frame[frame["date"].astype(str) >= cut].reset_index(drop=True)
+    fee_waived = props_exam.venue_for(0.0, False)
+    as_quoted = pnl.KALSHI
+    table = props_exam.posterior_comparison(second, "model", "p_over_sd", tau=0.7,
+                                            threshold=0.02,
+                                            venue_fee_waived=fee_waived,
+                                            venue_as_quoted=as_quoted,
+                                            draws=200, seed=0)
+    assert list(table["rule"].str.startswith(("threshold @ 2pt", "posterior",
+                                              "threshold @ matched")))
+    posterior_row = table[table["rule"].str.startswith("posterior")].iloc[0]
+    matched_row = table[table["rule"].str.startswith("threshold @ matched")].iloc[0]
+    assert abs(int(posterior_row["n_bets"]) - int(matched_row["n_bets"])) <= \
+        max(5, int(0.1 * max(int(posterior_row["n_bets"]), 1)))
+    # fee-waived ROI is never worse than as-quoted for the same rule (the fee
+    # only ever costs money on a winning-or-losing settle, never helps).
+    for r in table.itertuples(index=False):
+        if r.n_bets > 0:
+            assert r.roi_fee_waived >= r.roi_as_quoted - 1e-9
+
+
+def test_posterior_comparison_by_stat_reports_pooled_and_per_stat():
+    frame, cut = synthetic_frame()
+    second = frame[frame["date"].astype(str) >= cut].reset_index(drop=True)
+    fee_waived = props_exam.venue_for(0.0, False)
+    table = props_exam.posterior_comparison_by_stat(
+        second, "model", "p_over_sd", tau=0.7, threshold=0.02,
+        venue_fee_waived=fee_waived, venue_as_quoted=pnl.KALSHI,
+        draws=200, seed=0)
+    stats = set(table["stat"])
+    assert "all" in stats
+    assert stats - {"all"} == set(second["prop_stat"].unique())
+    assert len(table) == 3 * len(stats)   # three rules per stat group

--- a/tests/test_sim/test_lineups.py
+++ b/tests/test_sim/test_lineups.py
@@ -134,6 +134,40 @@ def test_a_scalar_ballast_applies_to_every_component():
             (num + 100 * LEAGUE[f"rate_{c}"]) / (den + 100))
 
 
+def test_alpha_beta_reproduce_the_rate_exactly():
+    """The Beta pseudo-counts `marcel_rates` exposes must mean exactly `rate_c`.
+
+    BAS-70 (docs/posterior-props.md): the Beta was implicit in the ballast
+    arithmetic all along, so `alpha/(alpha+beta)` has to equal the existing
+    `rate_c` to numerical precision, not just approximately.
+    """
+    row = counts(1, 2026, 300, k=30, bb=28, hr=15, h=90, doubles=20)
+    rates = lu.marcel_rates(frame([row]), 2026, LEAGUE)
+    for c in lu.COMPONENTS:
+        alpha, beta = rates.loc[1, f"alpha_{c}"], rates.loc[1, f"beta_{c}"]
+        assert alpha / (alpha + beta) == pytest.approx(rates.loc[1, f"rate_{c}"], abs=1e-12)
+
+
+def test_alpha_beta_present_with_no_history():
+    """A batter with no rows still gets a Beta — pure ballast at the league rate."""
+    rates = lu.marcel_rates(frame([counts(1, 2026, 0, k=0, bb=0, hr=0, h=0)]),
+                            2026, LEAGUE)
+    for c in lu.COMPONENTS:
+        alpha, beta = rates.loc[1, f"alpha_{c}"], rates.loc[1, f"beta_{c}"]
+        assert alpha / (alpha + beta) == pytest.approx(LEAGUE[f"rate_{c}"], abs=1e-12)
+        assert alpha == pytest.approx(lu.BALLAST[c] * LEAGUE[f"rate_{c}"])
+
+
+def test_existing_columns_are_unchanged_by_the_beta_columns():
+    """Adding alpha/beta must not perturb pa_weighted or any rate_c column."""
+    row = counts(1, 2026, 300, k=30, bb=28, hr=15, h=90, doubles=20)
+    rates = lu.marcel_rates(frame([row]), 2026, LEAGUE)
+    for c in ("pa_weighted", *lu.RATE_COLS):
+        assert c in rates.columns
+    for c in lu.COMPONENTS:
+        assert f"alpha_{c}" in rates.columns and f"beta_{c}" in rates.columns
+
+
 def test_zero_plate_appearances_gives_exactly_league_average():
     rates = lu.marcel_rates(frame([counts(1, 2026, 0, k=0, bb=0, hr=0, h=0)]),
                             2026, LEAGUE)


### PR DESCRIPTION
Opened before any arm is priced so the pre-registration in `docs/posterior-props.md` is timestamped. The pricing and selection work lands on this branch as it finishes.

## Why

BAS-69 left the hierarchical K% arm level with tuned Marcel on point accuracy. The one asset the Bayesian track has that Marcel structurally cannot offer — a distribution instead of a number — has never been spent. `docs/modelling-roadmap.md` §1 names three consumers; the simulator was tested and failed (no over-confidence to fix). The two left are prop pricing and stake sizing, where money is the exam.

## A correction first

The roadmap says Kelly under parameter uncertainty is "provably not Kelly at the mean" and the correct stake shades down. **For a one-shot binary contract this is false.** Expected log growth `p·log(1+f(1−c)/c) + (1−p)·log(1−f)` is linear in `p`, so its expectation over any posterior is the plug-in expression at the posterior mean. Checked numerically before the doc was written: Beta posteriors with sd from 0.015 to 0.148 give the same optimal fraction to five decimals. What feels like Kelly overbetting on a prop is selection on a noisy edge — a winner's curse on the *mean* — which shading the stake cannot fix. So posterior Kelly is deliberately not built; a test pins the linearity result.

## What is built

The hitter rates behind every prop (`lineups.marcel_rates`) are already the mean of `Beta(num_w + ballast·lg, (den_w − num_w) + ballast·(1−lg))`. Expose the pseudo-counts; no new fit.

1. **Beta-binomial pricing** — `P(over)` as the marginal over the rate, Monte Carlo through the five component Betas, alongside the existing point price. Convex at tail lines, which is where `props.py` already admits the Poisson is thin.
2. **Selection on `P(edge > 0) > τ`** instead of `|edge| > 2 pts`, τ chosen walk-forward on the first half by date and scored on the second, reported at a matched bet count.

## Pre-registered predictions

1. Beta-binomial improves paired Brier by 0.0002–0.0010, clustered |t| > 2, concentrated at lines with over-rate < .15.
2. `P(edge>0)` selection beats the threshold rule by 1–3 points of fee-waived ROI at matched bet count.
3. Neither makes props profitable after the Kalshi taker fee.

Vacuity check: median posterior sd of `P(over)` below 0.005 means neither is testable, and says the hierarchical model's wider posterior is the one to bring.

[BAS-70](https://linear.app/sigils/issue/BAS-70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_