### PR TITLE
Retry transient Savant failures in the Statcast ingest

### DIFF
--- a/src/data/statcast_savant.py
+++ b/src/data/statcast_savant.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import logging
+import time
 from datetime import date, timedelta
 
 import pandas as pd
@@ -23,6 +24,15 @@ CSV_URL = "https://baseballsavant.mlb.com/statcast_search/csv"
 # Savant caps an export around 25k rows; stay well under it per chunk.
 ROW_CAP = 24_000
 DEFAULT_CHUNK_DAYS = 3
+
+# Savant answers a season pull with ~70 CSV exports over fifteen minutes, and
+# on 2026-09-09 one of them came back 502 — a gateway hiccup on the 2026-07-10
+# window after 482,204 pitches had already been fetched. Without a retry the
+# whole run died and nothing reached R2. A 5xx, a dropped connection or a
+# timeout is retried on a doubling backoff (2, 4, 8, 16, 32 s); a 4xx is not,
+# because a bad request will not get better by asking again.
+RETRIES = 5
+BACKOFF_BASE_SECONDS = 2.0
 
 
 def _params(start: date, end: date, season: int) -> dict:
@@ -42,14 +52,47 @@ def _params(start: date, end: date, season: int) -> dict:
     }
 
 
+def _transient(exc: Exception) -> bool:
+    """Is this failure the kind a second try can fix?"""
+    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+        return True
+    if isinstance(exc, requests.HTTPError):
+        resp = getattr(exc, "response", None)
+        status = getattr(resp, "status_code", None)
+        return status is not None and status >= 500
+    return False
+
+
+def _get_with_retry(sess, params: dict, timeout: float,
+                    retries: int = RETRIES, sleep=time.sleep):
+    """`sess.get` plus `raise_for_status`, retried on transient failures only."""
+    last: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            r = sess.get(CSV_URL, params=params, timeout=timeout,
+                         headers={"User-Agent": "baseball-projections/0.1"})
+            r.raise_for_status()
+            return r
+        except Exception as exc:                      # noqa: BLE001 — classified below
+            if not _transient(exc) or attempt == retries:
+                raise
+            last = exc
+            wait = BACKOFF_BASE_SECONDS * (2 ** attempt)
+            logger.warning("%s..%s: %s — retry %d/%d in %.0fs",
+                           params.get("game_date_gt"), params.get("game_date_lt"),
+                           exc, attempt + 1, retries, wait)
+            sleep(wait)
+    raise last  # pragma: no cover — the loop either returns or raises
+
+
 def fetch_range(start: date, end: date, season: int | None = None,
-                timeout: float = 180.0, session: requests.Session | None = None) -> pd.DataFrame:
-    """One Savant CSV export. Raises on HTTP error or unparseable body."""
+                timeout: float = 180.0, session: requests.Session | None = None,
+                retries: int = RETRIES, sleep=time.sleep) -> pd.DataFrame:
+    """One Savant CSV export. Raises on a non-transient HTTP error, on a
+    transient one that outlasts `retries`, or on an unparseable body."""
     season = season or start.year
     sess = session or requests
-    r = sess.get(CSV_URL, params=_params(start, end, season), timeout=timeout,
-                 headers={"User-Agent": "baseball-projections/0.1"})
-    r.raise_for_status()
+    r = _get_with_retry(sess, _params(start, end, season), timeout, retries, sleep)
     text = r.content.decode("utf-8-sig")
     if not text.strip() or text.lstrip().startswith("<"):
         raise ValueError(f"non-CSV response for {start}..{end}")

--- a/tests/test_data/test_statcast_savant.py
+++ b/tests/test_data/test_statcast_savant.py
@@ -86,3 +86,66 @@ def test_html_error_page_is_rejected():
 def test_backwards_range_rejected():
     with pytest.raises(ValueError):
         ss.fetch_season(2026, date(2026, 5, 1), date(2026, 4, 1))
+
+
+# ── retries ──────────────────────────────────────────────────────────────
+
+import requests as _requests
+
+
+class _FlakySession:
+    """Fails the first `failures` calls with `exc_factory()`, then serves rows."""
+
+    def __init__(self, failures, exc_factory, rows=5):
+        self.failures, self.exc_factory, self.rows = failures, exc_factory, rows
+        self.calls = 0
+
+    def get(self, url, params=None, timeout=None, headers=None):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise self.exc_factory()
+        df = pd.DataFrame({"game_pk": range(self.rows), "at_bat_number": [1] * self.rows,
+                           "pitch_number": [1] * self.rows})
+        return FakeResponse(df.to_csv(index=False))
+
+
+def _http_error(status):
+    resp = _requests.Response()
+    resp.status_code = status
+    return _requests.HTTPError(f"{status}", response=resp)
+
+
+def test_a_502_is_retried_and_the_pull_succeeds():
+    """The 2026-09-09 failure: one gateway error mid-season killed the run."""
+    sess = _FlakySession(failures=2, exc_factory=lambda: _http_error(502))
+    waits = []
+    df = ss.fetch_range(date(2026, 7, 10), date(2026, 7, 12), 2026,
+                        session=sess, sleep=waits.append)
+    assert len(df) == 5 and sess.calls == 3
+    assert waits == [2.0, 4.0]          # doubling backoff, one wait per failure
+
+
+def test_connection_errors_and_timeouts_are_retried():
+    for exc in (_requests.ConnectionError, _requests.Timeout):
+        sess = _FlakySession(failures=1, exc_factory=exc)
+        df = ss.fetch_range(date(2026, 7, 10), date(2026, 7, 12), 2026,
+                            session=sess, sleep=lambda s: None)
+        assert len(df) == 5 and sess.calls == 2
+
+
+def test_a_4xx_is_not_retried():
+    """A bad request does not get better by asking again."""
+    sess = _FlakySession(failures=1, exc_factory=lambda: _http_error(404))
+    with pytest.raises(_requests.HTTPError):
+        ss.fetch_range(date(2026, 7, 10), date(2026, 7, 12), 2026,
+                       session=sess, sleep=lambda s: None)
+    assert sess.calls == 1
+
+
+def test_retries_are_bounded():
+    sess = _FlakySession(failures=99, exc_factory=lambda: _http_error(503))
+    with pytest.raises(_requests.HTTPError):
+        ss.fetch_range(date(2026, 7, 10), date(2026, 7, 12), 2026,
+                       session=sess, retries=3, sleep=lambda s: None)
+    assert sess.calls == 4              # one try plus three retries
+


### PR DESCRIPTION
## What broke

[Run 7](https://github.com/jackseeburger/baseball-projections/actions/runs/34362401311) of `statcast-ingest.yml` — the first with the `R2_*` secrets in place — fetched 482,204 pitches over fifteen minutes and died on a single Savant **502** for the 2026-07-10 window. `fetch_range` called `raise_for_status` with no retry, so one gateway hiccup on the seventieth CSV export discarded the previous sixty-nine and nothing reached R2.

## The fix

`fetch_range` now retries a 5xx, a dropped connection or a timeout on a doubling backoff (2, 4, 8, 16, 32 s — five tries) and does **not** retry a 4xx, since a bad request does not get better by asking again. The sleep is injectable so the tests run in milliseconds.

Tests: the 502 case from the log (two failures then success, waits `[2.0, 4.0]`), connection error and timeout, a 404 tried exactly once, and the bound (one try plus `retries`).

## Not in this PR

The reason one 502 could cost fifteen minutes is that the scheduled run re-fetches the entire season from March every day. That is [#89](https://github.com/jackseeburger/baseball-projections/issues/89): resume from the max `game_date` already on R2 with a small overlap, so a daily run fetches one or two chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_