### PR TITLE
Make the Statcast ingest incremental — resume from what R2 already holds

### DIFF
--- a/.github/workflows/statcast-ingest.yml
+++ b/.github/workflows/statcast-ingest.yml
@@ -5,6 +5,12 @@ name: Statcast ingest
 #
 # The archive had stopped at 2025, which meant every refit trained on a
 # season that had already ended. This job closes that gap nightly.
+#
+# With no `since` input, the script resumes incrementally: it reads the
+# season file already in R2 and only fetches the last few days plus a
+# short overlap, merging the result back in (rather than the ~15-minute
+# full-season re-download this job used to do every night). Set `since`
+# (or pass --full to the script) to force a full rebuild instead.
 on:
   schedule:
     # Odd minute on purpose — see nightly-odds.yml.

--- a/scripts/ingest_statcast.py
+++ b/scripts/ingest_statcast.py
@@ -1,15 +1,30 @@
-"""Pull a Statcast season from Baseball Savant into R2, and build PA outcomes.
+"""Pull Statcast from Baseball Savant into R2, and build PA outcomes.
 
 The season archive in R2 ended at 2025, so Bayesian refits saw nothing from
-the current year. This script closes that gap and can be re-run daily: it
-refetches the season (or a date window) and overwrites the year's files.
+the current year. This script closes that gap and can be re-run daily.
 
-    python scripts/ingest_statcast.py --season 2026
-    python scripts/ingest_statcast.py --season 2026 --since 2026-08-01
+Re-downloading the whole season every night was the original approach (~70
+CSV exports, ~15 minutes) but is wasteful once the season file already
+exists: with no `--since`, the script now reads the existing
+`statcast_<season>.parquet` from R2, resumes from `RESUME_OVERLAP_DAYS`
+days before its latest `game_date` (Savant posts corrections and a chunk
+boundary can land mid-game, so the existing dedup on
+`(game_pk, at_bat_number, pitch_number)` handles the short overlap), fetches
+only that tail, and merges it into the existing season file. If no season
+file exists yet in R2, it falls back to a full build from March 1.
+
+An explicit `--since` (or `--full`, which ignores whatever is in R2) is the
+deliberate full-rebuild path — it always fetches from that date instead of
+resuming, and is not merged against R2's copy: it fetches then overwrites,
+same as `--full`. `--full` alone reruns the season default window.
+
+    python scripts/ingest_statcast.py --season 2026                 # incremental, resumes from R2
+    python scripts/ingest_statcast.py --season 2026 --since 2026-08-01   # explicit rebuild from a date
+    python scripts/ingest_statcast.py --season 2026 --full          # full rebuild, March 1 on
     python scripts/ingest_statcast.py --season 2026 --no-upload --work-dir /tmp/sc
 
 Writes, for season Y:
-    s3://<bucket>/statcast/statcast_Y.parquet        pitch level
+    s3://<bucket>/statcast/statcast_Y.parquet        pitch level, whole season
     s3://<bucket>/pa_outcomes/pa_outcomes_Y.parquet  one row per plate appearance
 
 The PA file is what the Modal training functions read; getting it onto the
@@ -36,6 +51,16 @@ from src.data.statcast_savant import fetch_season
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("ingest")
+
+# Resuming from the existing R2 file's max game_date, minus this many days.
+# Savant posts corrections to already-published games, and a chunk boundary
+# can land mid-game, so the resume window overlaps the last few days already
+# on file rather than starting exactly where it left off. The existing
+# dedup on (game_pk, at_bat_number, pitch_number) — keeping the freshly
+# fetched copy of a duplicate over the stale one — absorbs the overlap.
+RESUME_OVERLAP_DAYS = 3
+
+MERGE_KEYS = ("game_pk", "at_bat_number", "pitch_number")
 
 
 def iso_date(s: str) -> date:
@@ -81,6 +106,54 @@ def fetch_to_parquet(season: int, start: date | None, end: date | None,
     return out
 
 
+def resolve_resume_since(season: int, raw_dir: Path, s3=None) -> tuple[date, Path | None]:
+    """Where to resume an incremental (no `--since`) run from.
+
+    Downloads the existing `statcast_<season>.parquet` from R2, if any, and
+    returns the date `RESUME_OVERLAP_DAYS` before its latest `game_date`
+    plus the local path it was downloaded to (so it can be merged back in
+    later). If R2 has no season file yet, returns March 1 and `None` — a
+    full build, logged as such.
+    """
+    s3 = s3 or get_s3_client()
+    key = f"statcast/statcast_{season}.parquet"
+    existing_path = raw_dir / f"statcast_{season}_r2existing.parquet"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        s3.download_file(bucket(), key, str(existing_path))
+    except Exception as exc:                        # noqa: BLE001 — any failure means "not there"
+        logger.info("no existing s3://%s/%s in R2 (%s) — full build from %s",
+                    bucket(), key, exc, date(season, 3, 1))
+        return date(season, 3, 1), None
+
+    max_date = pd.to_datetime(
+        pq.read_table(existing_path, columns=["game_date"]).column("game_date").to_pandas()
+    ).max().date()
+    since = max_date - timedelta(days=RESUME_OVERLAP_DAYS)
+    logger.info("existing %s: max game_date %s — resuming from %s (%d-day overlap)",
+                key, max_date, since, RESUME_OVERLAP_DAYS)
+    return since, existing_path
+
+
+def merge_with_existing(existing_path: Path, fetched_path: Path, out_path: Path) -> Path:
+    """Concat the existing season file with a freshly fetched tail, dedup, sort.
+
+    The fetched copy of an overlapping pitch wins over the stale one, since
+    Savant may have posted a correction since the existing file was written.
+    """
+    existing = pq.read_table(existing_path).to_pandas()
+    fetched = pq.read_table(fetched_path).to_pandas()
+    combined = pd.concat([existing, fetched], ignore_index=True)
+    keys = [k for k in MERGE_KEYS if k in combined.columns]
+    if keys:
+        combined = combined.drop_duplicates(subset=keys, keep="last")
+    if "game_date" in combined.columns:
+        combined = combined.sort_values("game_date")
+    combined = combined.reset_index(drop=True)
+    combined.to_parquet(out_path, index=False)
+    return out_path
+
+
 def upload(path: Path, key: str) -> None:
     s3 = get_s3_client()
     s3.upload_file(str(path), bucket(), key)
@@ -91,8 +164,13 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--season", type=int, default=date.today().year)
-    ap.add_argument("--since", type=iso_date, help="start date (default: March 1)")
+    ap.add_argument("--since", type=iso_date,
+                    help="start date; forces a full (non-incremental) fetch from this date, "
+                         "not merged against R2 (default: resume from R2, or March 1 if absent)")
     ap.add_argument("--until", type=iso_date, help="end date (default: today)")
+    ap.add_argument("--full", action="store_true",
+                    help="ignore R2 and fetch the whole season from March 1 (or --since); "
+                         "alias for the explicit-rebuild path with no date override")
     ap.add_argument("--chunk-days", type=int, default=3)
     ap.add_argument("--work-dir", type=Path, default=Path("data/raw"))
     ap.add_argument("--no-upload", action="store_true", help="build files but skip R2")
@@ -106,8 +184,27 @@ def main() -> None:
         if not raw_path.exists():
             raise SystemExit(f"--skip-fetch given but {raw_path} does not exist")
         logger.info("reusing %s", raw_path)
-    else:
+    elif args.since is not None or args.full:
+        # Deliberate full-rebuild path: fetch the requested window from
+        # Savant and overwrite R2's copy outright, no merge.
+        mode = f"explicit --since {args.since}" if args.since is not None else "--full rebuild"
+        logger.info("mode: %s — fetching from scratch, no R2 merge", mode)
         raw_path = fetch_to_parquet(args.season, args.since, args.until, raw, args.chunk_days)
+        logger.info("fetched %d rows (full rebuild)", pq.read_table(raw_path).num_rows)
+    else:
+        since, existing_path = resolve_resume_since(args.season, raw)
+        if existing_path is None:
+            logger.info("mode: full build (no existing R2 file) — fetching from %s", since)
+            raw_path = fetch_to_parquet(args.season, since, args.until, raw, args.chunk_days)
+            logger.info("fetched %d rows (full build)", pq.read_table(raw_path).num_rows)
+        else:
+            logger.info("mode: incremental — fetching from %s", since)
+            fetched_path = fetch_to_parquet(args.season, since, args.until, raw, args.chunk_days)
+            fetched_rows = pq.read_table(fetched_path).num_rows
+            raw_path = merge_with_existing(existing_path, fetched_path, raw_path)
+            total_rows = pq.read_table(raw_path).num_rows
+            logger.info("fetched %d rows, merged into %d total rows for the season",
+                        fetched_rows, total_rows)
 
     pa = process_year(args.season, data_dir=str(raw))
     if pa.empty:

--- a/tests/test_scripts/test_ingest_statcast.py
+++ b/tests/test_scripts/test_ingest_statcast.py
@@ -1,0 +1,242 @@
+"""Incremental Statcast ingest: resume date, merge/dedup, and the full-rebuild
+escape hatches (`--since`, `--full`). No network — R2 is a fake S3 client and
+Savant is a fake session returning fixed rows per window."""
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "ingest_statcast", ROOT / "scripts/ingest_statcast.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ingest = _load()
+
+
+def _season_frame(dates, key_start=0):
+    """A pitch-level frame with `game_date` and the merge keys populated."""
+    n = len(dates)
+    return pd.DataFrame({
+        "game_pk": [key_start + i for i in range(n)],
+        "at_bat_number": [1] * n,
+        "pitch_number": [1] * n,
+        "game_date": dates,
+    })
+
+
+class FakeS3:
+    """Stands in for the R2 client: local files keyed by (bucket, key)."""
+
+    def __init__(self, objects: dict[str, Path]):
+        self.objects = objects          # key -> local path
+        self.downloaded = []
+        self.uploaded = []
+
+    def download_file(self, bucket, key, path):
+        self.downloaded.append(key)
+        if key not in self.objects:
+            raise FileNotFoundError(f"no such key: {key}")
+        import shutil
+        shutil.copy(self.objects[key], path)
+
+    def upload_file(self, path, bucket, key):
+        self.uploaded.append(key)
+        self.objects[key] = Path(path)
+
+
+# ── resolve_resume_since ────────────────────────────────────────────────
+
+def test_resume_since_is_max_game_date_minus_overlap(tmp_path):
+    existing = tmp_path / "existing.parquet"
+    _season_frame(["2026-06-01", "2026-06-02", "2026-06-05"]).to_parquet(existing, index=False)
+    s3 = FakeS3({"statcast/statcast_2026.parquet": existing})
+
+    since, existing_path = ingest.resolve_resume_since(2026, tmp_path / "work", s3=s3)
+
+    assert since == date(2026, 6, 5) - pd_timedelta(ingest.RESUME_OVERLAP_DAYS)
+    assert existing_path is not None and existing_path.exists()
+
+
+def pd_timedelta(days):
+    from datetime import timedelta
+    return timedelta(days=days)
+
+
+def test_missing_object_falls_back_to_march_1(tmp_path):
+    s3 = FakeS3({})  # nothing in R2
+
+    since, existing_path = ingest.resolve_resume_since(2026, tmp_path / "work", s3=s3)
+
+    assert since == date(2026, 3, 1)
+    assert existing_path is None
+
+
+# ── merge_with_existing ─────────────────────────────────────────────────
+
+def test_merge_dedups_overlap_and_keeps_whole_season(tmp_path):
+    existing_path = tmp_path / "existing.parquet"
+    fetched_path = tmp_path / "fetched.parquet"
+    out_path = tmp_path / "out.parquet"
+
+    # Existing season file: March through the overlap window (June 2-5).
+    existing = _season_frame(
+        ["2026-03-01", "2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05"], key_start=0)
+    existing.to_parquet(existing_path, index=False)
+
+    # Freshly fetched tail re-covers June 2-5 (the overlap) plus new June 6-7.
+    fetched = _season_frame(
+        ["2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05", "2026-06-06", "2026-06-07"],
+        key_start=1)  # same game_pk values as the overlapping rows in `existing`
+    fetched.to_parquet(fetched_path, index=False)
+
+    out = ingest.merge_with_existing(existing_path, fetched_path, out_path)
+    merged = pd.read_parquet(out)
+
+    # March 1 (only in existing) + the 6 fetched dates = 7 rows, not 5 + 6 = 11.
+    assert len(merged) == 7
+    assert sorted(merged["game_date"]) == [
+        "2026-03-01", "2026-06-02", "2026-06-03", "2026-06-04",
+        "2026-06-05", "2026-06-06", "2026-06-07",
+    ]
+    # sorted by game_date
+    assert list(merged["game_date"]) == sorted(merged["game_date"])
+
+
+def test_merge_keeps_fetched_copy_on_overlap(tmp_path):
+    """The freshly fetched row wins over the stale existing one for the same key."""
+    existing_path = tmp_path / "existing.parquet"
+    fetched_path = tmp_path / "fetched.parquet"
+    out_path = tmp_path / "out.parquet"
+
+    existing = pd.DataFrame({"game_pk": [1], "at_bat_number": [1], "pitch_number": [1],
+                             "game_date": ["2026-06-02"], "estimated_woba": [0.300]})
+    existing.to_parquet(existing_path, index=False)
+    fetched = pd.DataFrame({"game_pk": [1], "at_bat_number": [1], "pitch_number": [1],
+                            "game_date": ["2026-06-02"], "estimated_woba": [0.410]})
+    fetched.to_parquet(fetched_path, index=False)
+
+    out = ingest.merge_with_existing(existing_path, fetched_path, out_path)
+    merged = pd.read_parquet(out)
+
+    assert len(merged) == 1
+    assert merged["estimated_woba"].iloc[0] == pytest.approx(0.410)
+
+
+# ── main(): explicit --since / --full bypass R2 ─────────────────────────
+
+def test_explicit_since_skips_r2_resume(monkeypatch, tmp_path):
+    calls = {"resolve": 0, "fetch": []}
+
+    def fake_resolve(season, raw_dir, s3=None):
+        calls["resolve"] += 1
+        return date(season, 3, 1), None
+
+    def fake_fetch(season, start, end, raw_dir, chunk_days):
+        calls["fetch"].append(start)
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        out = raw_dir / f"statcast_{season}.parquet"
+        _season_frame(["2026-08-01"]).to_parquet(out, index=False)
+        return out
+
+    def fake_process_year(season, data_dir):
+        return pd.DataFrame({
+            "game_pk": [1], "is_k": [0], "is_bb": [0], "is_hr": [0],
+        })
+
+    monkeypatch.setattr(ingest, "resolve_resume_since", fake_resolve)
+    monkeypatch.setattr(ingest, "fetch_to_parquet", fake_fetch)
+    monkeypatch.setattr(ingest, "process_year", fake_process_year)
+
+    argv = ["ingest_statcast.py", "--season", "2026", "--since", "2026-08-01",
+            "--work-dir", str(tmp_path), "--no-upload"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    ingest.main()
+
+    assert calls["resolve"] == 0, "--since must not touch R2 at all"
+    assert calls["fetch"] == [date(2026, 8, 1)]
+
+
+def test_full_flag_skips_r2_resume(monkeypatch, tmp_path):
+    calls = {"resolve": 0, "fetch": []}
+
+    def fake_resolve(season, raw_dir, s3=None):
+        calls["resolve"] += 1
+        return date(season, 3, 1), None
+
+    def fake_fetch(season, start, end, raw_dir, chunk_days):
+        calls["fetch"].append(start)
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        out = raw_dir / f"statcast_{season}.parquet"
+        _season_frame(["2026-03-01"]).to_parquet(out, index=False)
+        return out
+
+    def fake_process_year(season, data_dir):
+        return pd.DataFrame({"game_pk": [1], "is_k": [0], "is_bb": [0], "is_hr": [0]})
+
+    monkeypatch.setattr(ingest, "resolve_resume_since", fake_resolve)
+    monkeypatch.setattr(ingest, "fetch_to_parquet", fake_fetch)
+    monkeypatch.setattr(ingest, "process_year", fake_process_year)
+
+    argv = ["ingest_statcast.py", "--season", "2026", "--full",
+            "--work-dir", str(tmp_path), "--no-upload"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    ingest.main()
+
+    assert calls["resolve"] == 0, "--full must not touch R2's resume logic"
+    assert calls["fetch"] == [None], "--full with no --since fetches the default March-1 window"
+
+
+def test_default_mode_resumes_and_merges(monkeypatch, tmp_path):
+    """No --since / --full: reads R2's resume date and merges the fetched tail."""
+    calls = {"resolve": [], "fetch": [], "merge": []}
+
+    def fake_resolve(season, raw_dir, s3=None):
+        existing_path = raw_dir / "existing.parquet"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        _season_frame(["2026-03-01", "2026-06-02"]).to_parquet(existing_path, index=False)
+        calls["resolve"].append(season)
+        return date(2026, 6, 2), existing_path
+
+    def fake_fetch(season, start, end, raw_dir, chunk_days):
+        calls["fetch"].append(start)
+        out = raw_dir / f"statcast_{season}_fetched.parquet"
+        _season_frame(["2026-06-02", "2026-06-03"], key_start=5).to_parquet(out, index=False)
+        return out
+
+    def fake_merge(existing_path, fetched_path, out_path):
+        calls["merge"].append((existing_path, fetched_path))
+        merged = pd.concat([pd.read_parquet(existing_path), pd.read_parquet(fetched_path)])
+        merged = merged.drop_duplicates(subset=["game_pk"]).sort_values("game_date")
+        merged.to_parquet(out_path, index=False)
+        return out_path
+
+    def fake_process_year(season, data_dir):
+        return pd.DataFrame({"game_pk": [1], "is_k": [0], "is_bb": [0], "is_hr": [0]})
+
+    monkeypatch.setattr(ingest, "resolve_resume_since", fake_resolve)
+    monkeypatch.setattr(ingest, "fetch_to_parquet", fake_fetch)
+    monkeypatch.setattr(ingest, "merge_with_existing", fake_merge)
+    monkeypatch.setattr(ingest, "process_year", fake_process_year)
+
+    argv = ["ingest_statcast.py", "--season", "2026", "--work-dir", str(tmp_path), "--no-upload"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    ingest.main()
+
+    assert calls["resolve"] == [2026]
+    assert calls["fetch"] == [date(2026, 6, 2)]
+    assert len(calls["merge"]) == 1


### PR DESCRIPTION
Closes #89.

## What

`scripts/ingest_statcast.py` no longer re-downloads the whole season every night. With no `--since`, it reads `statcast/<season>.parquet` from R2 and resumes from its max `game_date` minus `RESUME_OVERLAP_DAYS = 3` (Savant posts corrections and a chunk boundary can land mid-game; the existing `(game_pk, at_bat_number, pitch_number)` dedup handles the overlap). The fetched tail is merged into the existing season file (`merge_with_existing`, fetched copy wins, sorted by date), so the uploaded parquet is still the whole season. No R2 object → March 1, logged as a full build.

An explicit `--since`, or the new `--full`, bypasses R2 for a deliberate rebuild. Workflow comment block and docstring updated; the workflow itself needs no change.

A daily run now fetches one or two chunks, and a failure costs one chunk instead of fifteen minutes.

## Checks

`tests/test_scripts/test_ingest_statcast.py` (fake S3 client, no network): resume-date math, missing-object fallback, merge dedup and whole-season retention, `--since`/`--full` bypass. Agent's full suite: 1360 passed; data + scripts on this tree: 78 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_