### PR TITLE
Statcast ingest: the PA outcomes directory is an argument, not a constant

### DIFF
--- a/scripts/ingest_statcast.py
+++ b/scripts/ingest_statcast.py
@@ -173,6 +173,8 @@ def main() -> None:
                          "alias for the explicit-rebuild path with no date override")
     ap.add_argument("--chunk-days", type=int, default=3)
     ap.add_argument("--work-dir", type=Path, default=Path("data/raw"))
+    ap.add_argument("--pa-dir", type=Path, default=Path("data/parquet/pa_outcomes"),
+                    help="where the season's PA outcomes parquet is written")
     ap.add_argument("--no-upload", action="store_true", help="build files but skip R2")
     ap.add_argument("--skip-fetch", action="store_true",
                     help="reuse an existing statcast_<season>.parquet in --work-dir")
@@ -209,7 +211,10 @@ def main() -> None:
     pa = process_year(args.season, data_dir=str(raw))
     if pa.empty:
         raise SystemExit(f"no plate appearances built for {args.season}")
-    pa_dir = Path("data/parquet/pa_outcomes")
+    # Never a hard-coded path: the tests drive main() from the repo root, and
+    # the one time this was fixed at data/parquet/pa_outcomes a test run
+    # overwrote the real 2026 file with a four-column fixture.
+    pa_dir = args.pa_dir
     pa_dir.mkdir(parents=True, exist_ok=True)
     pa_path = pa_dir / f"pa_outcomes_{args.season}.parquet"
     pa.to_parquet(pa_path, index=False)

--- a/tests/test_scripts/test_ingest_statcast.py
+++ b/tests/test_scripts/test_ingest_statcast.py
@@ -160,7 +160,7 @@ def test_explicit_since_skips_r2_resume(monkeypatch, tmp_path):
     monkeypatch.setattr(ingest, "process_year", fake_process_year)
 
     argv = ["ingest_statcast.py", "--season", "2026", "--since", "2026-08-01",
-            "--work-dir", str(tmp_path), "--no-upload"]
+            "--work-dir", str(tmp_path), "--pa-dir", str(tmp_path / "pa"), "--no-upload"]
     monkeypatch.setattr(sys, "argv", argv)
 
     ingest.main()
@@ -191,7 +191,7 @@ def test_full_flag_skips_r2_resume(monkeypatch, tmp_path):
     monkeypatch.setattr(ingest, "process_year", fake_process_year)
 
     argv = ["ingest_statcast.py", "--season", "2026", "--full",
-            "--work-dir", str(tmp_path), "--no-upload"]
+            "--work-dir", str(tmp_path), "--pa-dir", str(tmp_path / "pa"), "--no-upload"]
     monkeypatch.setattr(sys, "argv", argv)
 
     ingest.main()
@@ -232,7 +232,7 @@ def test_default_mode_resumes_and_merges(monkeypatch, tmp_path):
     monkeypatch.setattr(ingest, "merge_with_existing", fake_merge)
     monkeypatch.setattr(ingest, "process_year", fake_process_year)
 
-    argv = ["ingest_statcast.py", "--season", "2026", "--work-dir", str(tmp_path), "--no-upload"]
+    argv = ["ingest_statcast.py", "--season", "2026", "--work-dir", str(tmp_path), "--pa-dir", str(tmp_path / "pa"), "--no-upload"]
     monkeypatch.setattr(sys, "argv", argv)
 
     ingest.main()


### PR DESCRIPTION
## What

Follow-up to #97. `scripts/ingest_statcast.py` wrote the season's PA outcomes to a hard-coded relative `data/parquet/pa_outcomes`, and the new tests drive `main()` from the repo root — so one local test run replaced the real `pa_outcomes_2026.parquet` with a four-column fixture, which then broke every 2024+ cell of the dense Bayes sweep (`No match for FieldRef.Name(batter)`).

`--pa-dir` (default: the old path) makes the destination explicit; the three `main()` tests pass `tmp_path`. The workflow needs no change.

## Checks

`tests/test_scripts/test_ingest_statcast.py`: 7 passed, and the real 2026 file is untouched afterwards (verified by mtime). 2026 PA outcomes re-downloaded from R2 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_