### PR TITLE
docs: pre-register BAS-75 swing decisions and BAS-80 pitcher-Marcel calibration; the gate gains a covariate-share consequence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,15 @@ Consequences:
 - **Agreement with FanGraphs is not a score.** The coin-flip control proved
   September playoff odds can't distinguish models; use per-game Brier and
   component MAE.
+- **A covariate has to earn its own gain (from 2026-09-09, BAS-80).** A
+  layer-1 measurement is served as a covariate only if the arm clears the
+  gate *and* its covariate-only share — the arm against the same shape with
+  the covariate removed (the recalibration control) — clears |t| > 2.5 on
+  the same cells. BAS-79 served two components whose gain was mostly a
+  fitted intercept and withheld the one whose gain was all measurement,
+  because the rule looked only at the total. The rule in force at the time
+  is the one that counts, so BAS-72 and BAS-79 stand; this applies from the
+  next serving decision.
 
 Which *method* a station reaches for — hierarchical Bayes, machine learning,
 or neither — is a separate question from the bar it has to clear, and is

--- a/docs/pitcher-marcel-calibration.md
+++ b/docs/pitcher-marcel-calibration.md
@@ -1,0 +1,67 @@
+# The pitcher Marcel's walk-rate level, and re-scoring stuff against a calibrated baseline
+
+**BAS-80.** Station A, pitcher side. Pre-registered 2026-09-09, before any
+run.
+
+## Why
+
+BAS-79 found that of the additive stuff arm's −3.05% on BB/BF, −2.20% is a
+fitted intercept and only −0.87% is the covariate; for (BB+HBP)/BF the
+split is −2.04% against −0.64%. A constant that a control can fit and a
+measurement cannot explain is a calibration defect in the baseline —
+`marcel_pitcher_tuned` projects the league walk level wrongly — and it is
+being corrected under the stuff engine's name. Fix it where it lives, then
+re-score the stuff arm against the corrected baseline so the serving
+decision rests on measurement and not on an accident of the baseline.
+
+## What gets built
+
+1. **Calibrate.** `src/eval/marcel_pitcher_params.json` carries the tuned
+   ballast, weights, league mode and age curve per pitcher component. Refit
+   the **projected league rate** (the `LEAGUE_GRID` axis in
+   `src/eval/tuning.py`) and, if the tuning window asks for it, the ballast
+   for `p_bb_rate` and `p_bbhbp_rate` on the same 2019–2024 tuning window
+   and coordinate search the hitter side used (BAS-52 / BAS-25), scored
+   walk-forward on `scripts/run_pitcher_backtest.py`'s five cells. Diagnose
+   first: is the miss a level (league rate) or a spread (ballast) problem?
+   The intercept the control fitted says level; report which it is.
+2. **Re-score stuff.** Run `scripts/run_stuff_backtest.py` against the
+   calibrated baseline, all four arms (`stuff`, `stuff_recal`,
+   `stuff_additive`, `stuff_additive_recal`), same cells, same clustering.
+3. **Apply the serving rule in force now** (architecture.md §3, the
+   covariate-share consequence) to the re-scored table, and change the served
+   pitcher engines accordingly — including *un*-serving a component if it no
+   longer clears. The rule is written down before the run; what it says goes.
+
+## Pre-registered predictions
+
+1. **The miss is a level, not a spread.** Refitting the league mode alone
+   recovers ≥ 75% of the intercept the control found; the ballast moves by
+   less than one grid step.
+2. **Calibrated `marcel_pitcher_tuned` beats the current one on BB/BF by
+   1.5–2.5% of MAE** (clustered |t| > 3) and on (BB+HBP)/BF by 1.0–2.0%,
+   out of sample on the five cells. K/BF, HR/BF and BABIP move by < 0.3%.
+3. **Against the calibrated baseline the additive stuff arm's BB/BF gain
+   falls to 0.5–1.2%**, its covariate-only share stays at −0.6 to −1.0% (t
+   between −2 and −3), and **BB/BF no longer clears** the covariate-share
+   rule: `p_bb_rate` reverts to the calibrated Marcel. (BB+HBP)/BF likewise.
+4. **HR/BF is unchanged** (additive −2.5 to −3.0%, covariate share −2.0 to
+   −2.5%, |t| > 3) and stays served. **K/BF is unchanged** (additive −2.0 to
+   −2.5%, |t| between 2.3 and 2.7) and its serving decision is whatever the
+   rule says on the rerun — not chosen after seeing the number.
+
+### Vacuity check
+
+If the calibrated baseline does not beat the current one on BB/BF by at
+least 0.5% (|t| > 2), the intercept was not a calibration defect but
+something the walk-forward tuning cannot see; report it, leave the served
+engines as they are, and stop.
+
+### Failure conditions
+
+- Prediction 3 fails with BB/BF still clearing: the stuff aggregate carries
+  walk information the pre-registration did not credit; keep it served and
+  say so.
+- Prediction 2 holds but 1 fails (spread, not level): the pitcher Marcel's
+  ballast was mis-tuned; the doc records that and the serving decision still
+  follows the rule.

--- a/docs/swing-decisions.md
+++ b/docs/swing-decisions.md
@@ -1,0 +1,80 @@
+# Swing decisions — hitting layer 1 for K% and BB%
+
+**BAS-75.** Station A. Pre-registered 2026-09-09, before any run.
+
+## Why
+
+Contact quality (BAS-58, served by BAS-72) is the layer-1 measurement for
+what happens *after* the bat meets the ball: ISO, BABIP, HR/PA. K% and BB%
+have no measurement of their own; the served covariate reaches them only
+through contact-quality's denoising. What predicts them at the pitch grain
+is the decision *whether* to swing and *whether* the swing finds the ball:
+chase rate outside the zone, swing rate inside it, zone-contact rate, whiff
+rate. Public Statcast carries `description`, `zone`, `plate_x`/`plate_z`
+and the batter's `sz_top`/`sz_bot` for every pitch since 2015; `bat_speed`
+and `swing_length` from 2024, too thin to lean on and excluded here.
+
+## What gets built (the contact-quality shape, reused)
+
+- **Features, per batter per month**, additive counts so buckets sum
+  leak-free at first-of-month cutoffs: pitches seen in zone / out of zone
+  (Statcast `zone` 1–9 vs 11–14, with a `plate_x`/`plate_z` fallback against
+  the batter's own `sz_top`/`sz_bot` when `zone` is null); swings at each;
+  contacts (`hit_into_play`, `foul`, `foul_tip`) and whiffs
+  (`swinging_strike*`) at each; called strikes taken in zone. The same
+  swing mapping BAS-71 pinned. Rates are formed at read time from the
+  summed counts, never stored. → `data/features/swing_decisions_monthly.parquet`.
+- **Derived aggregates** (six, mirroring contact quality's six): chase
+  rate, in-zone swing rate, zone-contact rate, out-of-zone contact rate,
+  whiff-per-swing, called-strike-taken rate in zone. Each relative to the
+  league month.
+- **Stage 2:** the aggregates as covariates on `marcel_tuned`, the free fit
+  and the **additive** arm (baseline pinned at 1), with the recalibration
+  control (`_recal`) and the permuted control, on the dense harness's cells
+  (2022–2026 × May/Jul/Aug, hitters), paired per batter, SE clustered by
+  batter. Also the **incremental** arm: swing decisions *added to* the
+  served `contact_additive` engine, so the question "does this add to what
+  is already served" is answered directly.
+- No stage-1 model: these are rates, not a classifier's scores. There is
+  therefore no learned component to walk forward; the only fitted things
+  are stage 2's `(a, b, g)` on prior seasons.
+
+## Pre-registered predictions
+
+1. **BB%: information.** The additive arm beats `marcel_tuned` on BB% by
+   **2–4% of MAE**, clustered |t| > 3, and the gain **survives** at the
+   August cutoff and in the high-exposure tercile (contact-quality §6's
+   split). Approach changes precede walk-rate changes; that is why this is
+   the measurement K% and BB% lack.
+2. **K%: denoising.** The additive arm beats `marcel_tuned` on K% by
+   **1–3%**, |t| > 2.5, and the gain **evaporates** by August (under 0.5%
+   at the August cutoff) — whiff rate is the strikeout rate seen sooner,
+   not something beyond it.
+3. **Incremental over contact quality.** Added to the served
+   `contact_additive`, swing decisions improve BB% by ≥ 1.5% (|t| > 2.5)
+   and K% by ≥ 0.5%; contact quality and swing decisions are different
+   measurements and the gains are close to additive on BB%.
+4. **Covariate share.** Under architecture.md §3's covariate-share rule the
+   covariate-only share clears on BB% (|t| > 2.5) and does *not* on K%
+   after August is included — consistent with 1 and 2.
+5. **Nothing on the other three.** HR/PA, ISO and BABIP move by < 1% and
+   are not served from this measurement.
+
+### Vacuity check
+
+Year-over-year correlation of a batter's chase rate (≥ 500 pitches both
+years) must exceed **0.55**, and of zone-contact rate **0.50**. Below that
+the public zone field does not measure a stable skill and stage 2 cannot
+mean anything; report and stop.
+
+### Failure conditions
+
+- Prediction 1 fails but 2 holds: swing decisions are a variance reducer
+  for both; keep what clears, do not describe it as measuring approach.
+- Prediction 3 fails: the two measurements overlap; serve whichever clears
+  the covariate-share rule alone, and say so.
+
+## What ships
+
+Nothing in this pass. Serving is its own ticket, under the covariate-share
+rule, with a pre-registered Serving section here first.

--- a/docs/target-system.md
+++ b/docs/target-system.md
@@ -169,7 +169,7 @@ unstarted cell has a Linear issue; the status here is updated when one moves.
 | Component | L2 hierarchical model | L1 measurement feeding it |
 | --- | --- | --- |
 | K% (K/PA) | LIVE research arm: PA-level, season random walk, draws with `marcel_tuned` (BAS-69) | contact quality — **SERVED** (`contact_additive`, BAS-72) |
-| BB% (BB/PA) | IN FLIGHT — BAS-73 grid (smoke: a draw) | contact quality — **SERVED** (BAS-72); swing decisions — NOT STARTED, BAS-75 |
+| BB% (BB/PA) | IN FLIGHT — BAS-73 grid (smoke: a draw) | contact quality — **SERVED** (BAS-72); swing decisions — IN FLIGHT, BAS-75 (`docs/swing-decisions.md`) |
 | HR/PA | IN FLIGHT — BAS-73 grid (smoke: flat arm beats Marcel 11/12) | contact quality — **SERVED** (BAS-72), *information* |
 | ISO (per AB) | recovered HSGP model, never scored in the harness (#86) — after BAS-73 | contact quality — **SERVED** (BAS-72), *information* |
 | BABIP (per BIP) | recovered HSGP model, never scored (#86) — after BAS-73 | contact quality — **SERVED** (BAS-72), denoising; sprint speed — NOT STARTED |
@@ -179,7 +179,7 @@ unstarted cell has a Linear issue; the status here is updated when one moves.
 | Component | L2 hierarchical model | L1 measurement feeding it |
 | --- | --- | --- |
 | K/BF | NOT STARTED — BAS-74 | stuff — gated (−3.2%, t −3.4; BAS-71); additive arm **withheld** at t 2.50 vs the 2.5 bar (BAS-79) |
-| BB/BF, (BB+HBP)/BF | NOT STARTED — BAS-74 | stuff — **SERVED** on BB/BF (`stuff_additive`, BAS-79), mostly a level correction (BAS-80); command / location — NOT STARTED, BAS-76 |
+| BB/BF, (BB+HBP)/BF | NOT STARTED — BAS-74 | stuff — **SERVED** on BB/BF (`stuff_additive`, BAS-79), mostly a level correction — calibration IN FLIGHT, BAS-80 (`docs/pitcher-marcel-calibration.md`); command / location — NOT STARTED, BAS-76 |
 | HR/BF | NOT STARTED — BAS-74 | stuff — **SERVED** (`stuff_additive`, −2.8%, all covariate; BAS-79); contact-quality-allowed — gated, *information* |
 | BABIP against | NOT STARTED — BAS-74 | contact-quality-allowed — gated |
 


### PR DESCRIPTION
Docs only, committed before either run starts.

- `docs/architecture.md` §3: a layer-1 measurement is served as a covariate only if the arm clears the gate **and** its covariate-only share (vs the recalibration control) clears |t| > 2.5. From 2026-09-09; BAS-72 and BAS-79 stand under the rule in force at the time.
- `docs/pitcher-marcel-calibration.md` (BAS-80): four predictions on refitting the pitcher Marcel's walk-rate level and re-scoring stuff against it — including that BB/BF will no longer clear and reverts to Marcel.
- `docs/swing-decisions.md` (BAS-75): five predictions — BB% information (2–4%, survives August), K% denoising (1–3%, evaporates), incremental over `contact_additive`, covariate share, nothing on the other three — with a year-over-year stability vacuity check.
- Inventory updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_