### PR TITLE
Schedule watchdog: a later successful re-run rescues a failed slot

### DIFF
--- a/scripts/check_schedules.py
+++ b/scripts/check_schedules.py
@@ -456,6 +456,11 @@ class SlotOutcome:
     slot: datetime
     run: dict | None = None
     started: datetime | None = None
+    # A later run in the same window that concluded successfully after `run`
+    # failed. The issue text tells the owner to re-run the workflow by hand;
+    # a watchdog that then kept reporting the original failure until the
+    # next slot came due would be contradicting its own remedy.
+    rescue: dict | None = None
 
     @property
     def late_hours(self) -> float | None:
@@ -551,7 +556,14 @@ def check_workflow(path: str, crons: list[str], workflow: dict | None,
                       if start >= slot and (upper is None or start < upper)]
         if attributed:
             run, start = min(attributed, key=lambda pair: pair[1])
-            outcomes.append(SlotOutcome(slot=slot, run=run, started=start))
+            rescue = None
+            if run.get("conclusion") in BAD_CONCLUSIONS:
+                later_ok = [(r, s) for r, s in attributed
+                            if s > start and r.get("conclusion") == "success"]
+                if later_ok:
+                    rescue = max(later_ok, key=lambda pair: pair[1])[0]
+            outcomes.append(SlotOutcome(slot=slot, run=run, started=start,
+                                        rescue=rescue))
         else:
             outcomes.append(SlotOutcome(slot=slot))
     result.slots = outcomes
@@ -579,7 +591,14 @@ def check_workflow(path: str, crons: list[str], workflow: dict | None,
              f"({format_hours(newest.late_hours)} after the slot, "
              f"event={newest.run.get('event', '?')})")
 
-    if conclusion in BAD_CONCLUSIONS:
+    if conclusion in BAD_CONCLUSIONS and newest.rescue is not None:
+        rescue = newest.rescue
+        result.run_url = rescue.get("html_url")
+        result.detail = (f"{where}, conclusion={conclusion}; rescued by run "
+                         f"#{rescue.get('run_number', '?')} "
+                         f"(event={rescue.get('event', '?')}, "
+                         f"conclusion=success)")
+    elif conclusion in BAD_CONCLUSIONS:
         result.status = "FAILED"
         result.detail = f"{where}, conclusion={conclusion}"
     elif conclusion is None:

--- a/tests/test_scripts/test_check_schedules.py
+++ b/tests/test_scripts/test_check_schedules.py
@@ -368,6 +368,27 @@ def test_a_manual_rescue_run_clears_the_alarm_and_is_labelled():
     assert "event=workflow_dispatch" in result.detail
 
 
+def test_a_failed_run_rescued_by_a_later_manual_run_is_not_failed():
+    """The issue's own remedy is 're-run the workflow by hand'. Once that
+    re-run succeeds in the same slot window the alarm has to clear, or the
+    watchdog contradicts itself until the next slot comes due."""
+    result = check([run("2026-09-03T09:25:00Z", conclusion="failure", number=6),
+                    run("2026-09-03T14:00:00Z", conclusion="success", number=8,
+                        event="workflow_dispatch")],
+                   "2026-09-03T15:43:00Z")
+    assert not result.failed and result.status != "FAILED"
+    assert "rescued by run #8" in result.detail
+    assert "event=workflow_dispatch" in result.detail
+
+
+def test_a_later_failed_rerun_does_not_rescue():
+    result = check([run("2026-09-03T09:25:00Z", conclusion="failure", number=6),
+                    run("2026-09-03T14:00:00Z", conclusion="failure", number=7,
+                        event="workflow_dispatch")],
+                   "2026-09-03T15:43:00Z")
+    assert result.status == "FAILED"
+
+
 def test_a_failed_run_is_reported_even_though_it_started():
     result = check([run("2026-09-03T09:25:00Z", conclusion="failure")],
                    "2026-09-03T15:43:00Z")


### PR DESCRIPTION
## What

#83's own text says "re-run the workflow by hand to recover", but `scripts/check_schedules.py` judged a slot by the *earliest* run in its window — right for lateness, wrong for the verdict — so the Statcast ingest stayed `FAILED` after runs 7 and 8 (both `workflow_dispatch`, both green) until the next scheduled slot came due.

Now, when the slot's first run failed and a later run in the same window concluded `success`, the slot is not FAILED; the detail names the rescuing run and its event. A later failed re-run does not rescue. Lateness is still measured from the first run.

## Checks

`tests/test_scripts/test_check_schedules.py`: 56 passed (two new: rescue clears, a failed re-run does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_