### PR TITLE
docs: pre-register BAS-84 (joint multi-component model) and BAS-85 (measurement model)

### DIFF
--- a/docs/bayes-joint.md
+++ b/docs/bayes-joint.md
@@ -1,0 +1,68 @@
+# The joint multi-component hierarchical model
+
+**BAS-84.** Station A, layer 2. Pre-registered 2026-09-09 20:15 UTC in the
+Linear issue, before any run; this file mirrors that text.
+
+## Why
+
+The outcomes-only hierarchical model draws with tuned Marcel on K%, BB% and
+HR/PA (BAS-69, BAS-73). That is the expected result: a single-component
+random-effects model on the logit *is* Marcel with a learned ballast, and
+tuned Marcel already sits at that family's optimum. The Bayes model can
+only win by carrying structure Marcel cannot express. The first such
+structure is that the five components share one hitter: today each is fit
+alone, so a hitter's power tells the walk model nothing and his strikeouts
+tell the home-run model nothing. Teams fit these jointly.
+
+## What gets built
+
+`src/models/pa_joint.py`: one PyMC model over the same cells `pa_rate.py`
+uses, with a per-batter *vector* of abilities across components (K%, BB%,
+HR/PA in this pass) drawn from a multivariate normal with an LKJ(2)
+correlation prior and per-component scales; the ability walk (`sigma_step`
+per component) and the age curve stay per component; league trend,
+handedness and park per component as today. Each component keeps its own
+binomial likelihood on its own trials. `BayesArmConfig` gains `joint=True`;
+the dense sweep gets `--variants joint_walk`; the checkpoint keys on
+(component, season, cutoff) as before so the joint fit fills three
+components per cell.
+
+Scope: 2022/2024/2025/2026 × 12 biweekly cutoffs, 2 chains × 500 draws,
+cores=1, no pitcher effect, one fit per cell yielding all three
+components. Comparators on the common set, SE clustered by player:
+`bayes_walk` (the single-component model, same cells), `marcel_tuned`, and
+the served engine `contact_additive`.
+
+## Pre-registered predictions
+
+1. **The correlations are real.** Posterior correlation between the K% and
+   HR/PA abilities is positive and its 95% interval excludes zero at every
+   cutoff (power hitters strike out more); between BB% and K% it is
+   positive; if any interval straddles zero at more than a quarter of
+   cutoffs, the joint structure adds nothing and 2–4 are moot.
+2. **HR/PA gains from borrowing strength.** `joint_walk` beats `bayes_walk`
+   on HR/PA by ≥ 1.5% of MAE, clustered |t| > 2.5; the rare event is where
+   a second channel of information about the player is worth most.
+3. **K% and BB% draw** with `bayes_walk` (|Δ| ≤ 0.0003, |t| < 2): the
+   high-count components already saturate.
+4. **Against the served engine:** `joint_walk` vs `contact_additive` on
+   HR/PA is Δ < 0 with t < −2 *only if* prediction 2's gain exceeds contact
+   quality's own (≈ 3% on HR/PA); the honest expectation is that it does
+   not, and the joint model with the contact covariates (BAS-83's block)
+   is the arm that would.
+5. **Vacuity:** every `sigma_step` stays above 0.02 and no LKJ correlation
+   posterior is pinned at ±1.
+
+### Failure conditions
+
+- Prediction 1 fails: report, stop, do not tune the prior.
+- Prediction 2 fails with 1 holding: the components are correlated but the
+  correlation carries no predictive information beyond the player's own
+  history; say so in those words.
+
+## What ships
+
+Nothing in this pass. Serving is its own ticket under architecture.md §3.
+The joint model becomes the base the covariates (BAS-83) and the
+measurement channel (BAS-85, `docs/bayes-measurement.md`) build on,
+whatever the verdict.

--- a/docs/bayes-measurement.md
+++ b/docs/bayes-measurement.md
@@ -1,0 +1,62 @@
+# The measurement model: one latent talent, several observation channels
+
+**BAS-85.** Station A, layer 2. Pre-registered 2026-09-09 20:15 UTC in the
+Linear issue, before any run; this file mirrors that text.
+
+## Why
+
+Contact quality is served as a *covariate on Marcel* (BAS-72) and is being
+tested as a covariate inside the hierarchical model (BAS-83). Both treat
+the measurement as a fixed regressor. A team's model treats it as a second
+observation of the same latent talent: the hitter's true power produces
+both his home-run count (binomial, noisy at 600 PA) and his exit-velocity
+and launch-angle distribution (measured every batted ball, far less noisy).
+A measurement model with two observation channels and one latent state is
+how a 200-PA sample can carry a full-season posterior. This is the
+structure that lets the model *beat* the outcome-only ballast rather than
+tie it.
+
+## What gets built
+
+`src/models/pa_measurement.py`: per batter-season (or batter-month under
+the walk) one latent power state `theta_hr` and one latent contact state
+`theta_k`; HR/PA ~ Binomial(logistic(f(theta_hr) + …)) as today; barrel
+rate per batted ball ~ Binomial(logistic(g(theta_hr))) and mean exit
+velocity ~ Normal(h(theta_hr), sigma_ev/√BBE) as second and third
+channels; whiff share as the K% channel. Channel loadings are global
+parameters learned across players and seasons. Builds on the joint model
+(BAS-84) if it has landed, otherwise on `pa_rate.py`. Walk-forward exactly
+as the harness: at a cutoff, only batted balls strictly before it are
+observed. Cells, seasons, draws, comparators and clustering as in BAS-84;
+components K% and HR/PA.
+
+## Pre-registered predictions
+
+1. **The channels load.** Posterior loadings of barrel rate and exit
+   velocity on `theta_hr`, and of whiff share on `theta_k`, exclude zero at
+   every cutoff.
+2. **Early-season is where it wins.** At the May cutoffs, `measurement`
+   beats `contact_additive` on HR/PA by ≥ 3% of MAE (|t| > 2.5); at the
+   August cutoffs the gap is ≤ 1.5%. Information, not denoising, and most
+   of it when outcomes are thin.
+3. **Pooled over cutoffs:** `measurement` vs `contact_additive` on HR/PA is
+   Δ < 0, clustered t < −2 — the first arm that would replace the served
+   engine — and on K% is a draw within ±0.0005.
+4. **The posterior width is right:** the 80% posterior interval on the
+   rest-of-season rate covers the realised rate 75–85% of the time on the
+   common set; `contact_additive` has no interval and `bayes_walk`'s covers
+   < 75% at May.
+5. **Vacuity:** the latent-state scale stays above 0.02 and the loadings
+   are not degenerate (|corr| between any two channel loadings < 0.95).
+
+### Failure conditions
+
+- Prediction 3 fails with 1 and 2 holding: early-season gains exist but
+  wash out over a season; the model earns a place in the props engine
+  (short horizons), not the season projection, and the roadmap says so.
+- Prediction 1 fails: the channel definitions are wrong, fix before
+  reading anything else.
+
+## What ships
+
+Nothing in this pass. Serving is its own ticket under architecture.md §3.

--- a/docs/journey.md
+++ b/docs/journey.md
@@ -60,10 +60,18 @@ covariate earns ≥ 1.0% of MAE on its own. Every model decision from
 
 ## The plan from here, in order
 
-1. **BAS-83** — decide whether the hierarchical model, fed the
-   measurements, is the layer-2 engine. On outcomes alone it is a draw on
-   every component (BAS-69, BAS-73); the covariates are its remaining
-   case.
+1. **The layer-2 model track.** On outcomes alone the hierarchical model
+   is a draw on every component (BAS-69, BAS-73), and that is what the
+   math says it should be: a single-component random-effects model *is*
+   Marcel with a learned ballast. The model wins only by carrying
+   structure Marcel cannot express, so the track is three structural
+   models in order, each pre-registered and each kept whatever the
+   verdict: the covariates inside the likelihood (BAS-83, in flight), the
+   joint multi-component model with correlated player effects (BAS-84,
+   `docs/bayes-joint.md`), and the measurement model where Statcast is a
+   second observation of the same latent talent rather than a regressor
+   (BAS-85, `docs/bayes-measurement.md`). After those: time and age as a
+   process, and the posterior width scored at layer 7.
 2. **BAS-74**, the pitcher hierarchical model with stuff inside it; a
    command *level* aggregate (BAS-76's follow-up) once pre-registered.
 3. **ISO and BABIP** hierarchical models (their own denominators), after 1.

--- a/docs/target-system.md
+++ b/docs/target-system.md
@@ -126,7 +126,7 @@ one hid the fact that two of them are much emptier than the first.
 | | **Hitting** | **Pitching** | **Defence / catching** |
 |---|---|---|---|
 | **L1 Measurement** | batted ball → contact quality — **gated**, 7 of 8, not yet wired; HSGP version lost | pitch characteristics → "stuff" / run value — **not started** | fielding location → out probability — **not started** |
-| **L2 True talent** | K% BB% HR/PA BABIP ISO — tuned Marcel live; Bayesian arm DRAWS with it on K%, BB% and HR/PA (BAS-69, BAS-73) | K% BB% HR/BF BABIP-against, WHIP rate — **gated**, all five clear | framing runs, fielder runs — **in progress** (framing); no Marcel equivalent exists |
+| **L2 True talent** | K% BB% HR/PA BABIP ISO — tuned Marcel live; Bayesian arm DRAWS with it on K%, BB% and HR/PA (BAS-69, BAS-73); structural track IN FLIGHT: covariates in the likelihood (BAS-83), joint multi-component (BAS-84), measurement model (BAS-85) | K% BB% HR/BF BABIP-against, WHIP rate — **gated**, all five clear | framing runs, fielder runs — **in progress** (framing); no Marcel equivalent exists |
 | **L3 Playing time** | PA — **gated**, the biggest win in the repo | batters faced — **gated** (B-P) | innings by position — **does not exist** |
 | **L4 Assembly** | rates × PA → wOBA → wRC+ → oWAR | rates × BF → FIP / RA9 → pWAR | runs saved → dWAR |
 | ↓ | | | |


### PR DESCRIPTION
## Summary

Two pre-registrations for the layer-2 model track, mirroring the timestamped Linear text (BAS-84, BAS-85; 2026-09-09 20:15 UTC), committed before any run.

- **`docs/bayes-joint.md` (BAS-84):** one hierarchical model over K%, BB% and HR/PA with a per-batter ability *vector* under an LKJ correlation prior. Predictions: the K%–HR/PA correlation is real; HR/PA gains ≥ 1.5% of MAE from borrowing strength; K% and BB% draw; against the served engine it likely does not win alone.
- **`docs/bayes-measurement.md` (BAS-85):** latent talent observed through outcomes *and* Statcast batted-ball channels (barrel rate, exit velocity, whiff share) with learned loadings. Predictions: the channels load; the win is at the May cutoffs; pooled it is the first arm that would replace the served engine on HR/PA; the posterior width is calibrated.
- `docs/journey.md` and `docs/target-system.md` §2c: the layer-2 plan now reads as a structural track (covariates in the likelihood → joint → measurement → time process → posterior width at layer 7), with the reasoning that the outcomes-only model draws with tuned Marcel because it *is* Marcel with a learned ballast.

No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_