### PR TITLE
docs: pre-register BAS-92, the hierarchical posterior's width in the props price

### DIFF
--- a/docs/journey.md
+++ b/docs/journey.md
@@ -82,8 +82,12 @@ covariate earns ≥ 1.0% of MAE on its own. Every model decision from
    (BAS-85, `docs/bayes-measurement.md`). Park factors now exist (BAS-86, `docs/park-factors.md`): persistent,
    real, and useless multiplied onto Marcel because Marcel's inputs already
    carry the park; their place is the hierarchical models' offset, to be
-   scored there. After those: time and age as a process, and the posterior
-   width scored at layer 7.
+   scored there. After those: time and age as a process. The posterior
+   width at layer 7 is pre-registered (BAS-92, `docs/posterior-width.md`):
+   the served props mean with the hierarchical model's per-player width
+   in place of the Beta's, scored on BAS-70's own archive, HR contracts
+   primary, the one exam the Bayes arm can win without beating Marcel's
+   point estimate.
 2. **BAS-74**, the pitcher hierarchical model with stuff inside it; a
    command *level* aggregate (BAS-76's follow-up) once pre-registered.
 3. **ISO and BABIP** hierarchical models (their own denominators), after 1.

--- a/docs/posterior-width.md
+++ b/docs/posterior-width.md
@@ -1,0 +1,102 @@
+# The hierarchical posterior's width in the props price
+
+**BAS-92.** Layer 7. Follow-up to BAS-70 (`docs/posterior-props.md`).
+Pre-registered 2026-09-10 13:10 UTC in the Linear issue, before any run;
+this file mirrors that text.
+
+## Why
+
+BAS-70 spent Marcel's Beta posterior on the props price and found the
+marginal price better by .00003 Brier (nothing) and the `P(edge > 0)`
+selection rule worth 0.2 points of ROI at a matched bet count (nothing).
+Its diagnosis: the Beta's width barely varies across contracts
+(`p_over_sd` in a band of .008–.023 for three of four stats), so
+`P(edge > 0)` is a monotone relabel of the mean edge and selects the same
+bets. Its named next test: "a wider, more player-specific posterior, the
+hierarchical model's, with its drift term and population uncertainty".
+
+That posterior now exists on three components: `bayes_walk` on K%, BB%
+and HR/PA (BAS-73, `src/models/pa_rate.py`), draws with tuned Marcel on
+the mean, and carries per-player posterior sd (`<c>_std`) that Marcel
+structurally lacks: wide for a rookie or a player whose walk has drifted,
+narrow for a veteran. This is the one exam where the hierarchical model
+can win without beating Marcel's point estimate: the mean stays the
+served price, only the width changes.
+
+## What gets built
+
+- **Fits.** `bayes_walk` (numpyro, the single-component ability-walk arm
+  as in BAS-73) on K%, BB%, HR/PA for 2026 at the dense harness's
+  biweekly cutoffs 2026-07-15, 08-01, 08-15, 09-01, persisting the
+  per-player posterior mean and sd (seen and unseen batters; unseen get
+  the population projection's sd). Training seasons and cutoff rules
+  exactly as the dense harness (PA strictly before the cutoff).
+- **Arm `bayes_width`.** In `src/market/props.price`, for each batter and
+  each of K, BB, HR the Beta's total pseudo-count (α+β) is replaced by
+  the method-of-moments total implied by the Bayes posterior sd at the
+  most recent cutoff ≤ the game date, recentred on the served daily mean
+  (`rate_<c>` from `batter_rates`): the price sold is unchanged, the width
+  is the hierarchical model's. BABIP and ISO keep the Beta (no
+  hierarchical model exists for them). Pitcher strikeout props keep the
+  Beta (no pitcher-rate hierarchical model). The Bayes sd is therefore up
+  to 16 days stale relative to the daily mean; recorded, not corrected.
+- **Scoring.** `scripts/props_exam.py --matchup on --posterior`, the
+  served configuration, on the committed archive (61,738 settled
+  contracts, 455 games, 2026-07-31 → 09-02), first/second half split on
+  the median date (08-16), τ chosen on the first half, money on the
+  second, exactly as BAS-70. Primary set: **HR contracts** (11,896), where
+  the changed width is the HR/PA posterior alone. Secondary: hits and TB
+  (their width mixes Bayes K/BB/HR with the Beta on BABIP/ISO).
+  Strikeouts are unchanged and serve as the negative control (any
+  movement there is a bug).
+
+## Pre-registered predictions
+
+1. **(Vacuity, run first) The Bayes width is different information.** On
+   HR contracts, the Spearman correlation between the Beta `p_over_sd`
+   and the `bayes_width` `p_over_sd` is < 0.9, and at least 25% of HR
+   contracts change `p_over_sd` by more than 30%. Below either, the
+   single-component posterior's width is as uniform as the Beta's, the
+   test cannot resolve anything, and it says so.
+2. **(Selection) `P(edge > 0)` at τ chosen on the first half beats the
+   threshold rule at a matched bet count on the second half by ≥ 1.0
+   point of fee-waived ROI** on HR contracts, and ≥ 0.5 pooled over HR +
+   hits + TB. (BAS-70's number was +0.2 pooled with the Beta.)
+3. **(Winner's curse) The width separates real from spurious edges.**
+   Among second-half contracts with mean edge ≥ 2 points, fee-waived flat
+   return in the top tercile of `P(edge > 0)` exceeds the bottom tercile
+   by ≥ 2.0 points, on HR and pooled.
+4. **(Null) The marginal price does not move.** Paired Brier of
+   `p_over_bb` under `bayes_width` vs the Beta is within ±.0001 on every
+   stat: the mean carries the price, the width carries the selection.
+5. **(Negative control)** Strikeout contracts reproduce BAS-70's numbers
+   exactly.
+
+### Failure conditions
+
+If 1 fails, the doc says the single-component posterior width does not
+vary enough either, and the thread waits for the joint (BAS-84) and
+measurement (BAS-85) posteriors, whose widths carry more structure. If 2
+and 3 fail with 1 passing, the edge's noise is model error the posterior
+does not measure, and `P(edge > 0)` is retired as a selection rule for
+the props ledger. Hits after fee stays exploratory whatever happens; it
+is reported, not tested.
+
+## What ships
+
+Only if 2 holds with the second-half interval excluding zero on HR
+**and** 3 holds: the paper ledger's selection rule (Stage 0.1) changes to
+`P(edge > 0)` with the Bayes width, under a Stage 0 amendment with its
+own pre-registered thresholds, and the nightly refresh gains the three
+Bayes fits. Otherwise nothing ships; the arm stays behind a flag.
+
+## Risks recorded up front
+
+The Bayes sd is stale by up to 16 days. Method-of-moments Beta from a
+logit-normal posterior is an approximation (recorded; the alternative,
+pricing from draws, is the follow-up if the width matters). Half-split on
+date makes the second half 30,474 contracts, 17 game-days; intervals are
+wide. Multiple stats: the primary is HR, named here; the pooled numbers
+are secondary. The archive is the same 455 games BAS-70 scored, so this
+is a re-analysis of the same contracts with one changed input, not new
+data.

--- a/docs/target-system.md
+++ b/docs/target-system.md
@@ -112,8 +112,10 @@ leaves and carrying the variance.
 │  posterior rate ──► prop prices with real tails                  │
 │  posterior edge ──► Kelly that shades for uncertainty            │
 │  posterior WAR  ──► $/WAR ──► contract surplus value             │
-│  STATUS: props and Kelly live on POINT ESTIMATES — both wrong in  │
-│          a known direction. Contract valuation does not exist.    │
+│  STATUS: Beta width SPENT (BAS-70): price unchanged, selection    │
+│          a relabel, Kelly at the mean is right by proof. The      │
+│          hierarchical width is IN FLIGHT (BAS-92). Contract       │
+│          valuation does not exist.                                │
 └──────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/target-system.md
+++ b/docs/target-system.md
@@ -87,13 +87,13 @@ leaves and carrying the variance.
 │  What CHANGES: it runs on posterior DRAWS instead of point        │
 │  estimates, so uncertainty survives to everything below.          │
 │  STATUS: live on point estimates. Career WAR already does the     │
-│          draw version — see issue #75.                            │
+│          draw version — see issue #75.                           │
 └──────────────────────────────────────────────────────────────────┘
                               │
 ┌─ LAYER 5 · TEAM AND GAME ─────────────────────────── ARITHMETIC ─┐
 │  team runs ──► Pythagenpat ──► team strength                      │
 │  per game: log5 + HFA + starter FIP over his expected innings     │
-│            + availability-weighted pen + posted lineup            │
+│            + availability-weighted pen + posted lineup           │
 │  STATUS: live and gated. Best .24388 vs market .24156.            │
 └───────────────────────────────────────────────────────────────────┘
                               │
@@ -112,10 +112,10 @@ leaves and carrying the variance.
 │  posterior rate ──► prop prices with real tails                  │
 │  posterior edge ──► Kelly that shades for uncertainty            │
 │  posterior WAR  ──► $/WAR ──► contract surplus value             │
-│  STATUS: Beta width SPENT (BAS-70): price unchanged, selection    │
-│          a relabel, Kelly at the mean is right by proof. The      │
-│          hierarchical width is IN FLIGHT (BAS-92). Contract       │
-│          valuation does not exist.                                │
+│  STATUS: Beta width SPENT (BAS-70): price unchanged, selection   │
+│          a relabel, Kelly at the mean is right by proof. The     │
+│          hierarchical width is IN FLIGHT (BAS-92). Contract      │
+│          valuation does not exist.                               │
 └──────────────────────────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
## Summary

Pre-registration for BAS-92, the follow-up BAS-70 (`docs/posterior-props.md`) named: the served props mean with the hierarchical model's per-player posterior width in place of Marcel's Beta width. BAS-70 found the Beta's width barely varies across contracts, so `P(edge > 0)` was a relabel of the mean edge. `bayes_walk` on K%, BB% and HR/PA (BAS-73) carries a per-player sd that Marcel cannot; this is the one exam the Bayes arm can win without beating Marcel's point estimate.

Registers: fits at the four biweekly 2026 cutoffs covering the archive; a `bayes_width` arm that keeps the served daily mean and swaps the Beta's pseudo-count total for the one implied by the Bayes sd (K, BB, HR only; BABIP, ISO and pitcher K keep the Beta); scoring with BAS-70's own pipeline and archive; HR contracts primary; a vacuity check run first, a selection prediction, a winner's-curse prediction, a null on the price, strikeouts as the negative control; failure conditions and a ship rule. Nothing ships in this pass.

- `docs/posterior-width.md` (new); `docs/journey.md` item 1; `docs/target-system.md` layer-7 status box (BAS-70's Kelly retraction was not yet reflected there).

No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzgFgx3BJsbr7iSf4T8kAn)_